### PR TITLE
add ENABLE_ESMI_LIB to PREDEFINED in doxyfile

### DIFF
--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -2276,7 +2276,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = ENABLE_ESMI_LIB
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
add ENABLE_ESMI_LIB to PREDEFINED, to make sure the doxygen documentations contain the esmi functions as well