### PR TITLE
fix(python): fix comparison to None

### DIFF
--- a/amdsmi_cli/amdsmi_commands.py
+++ b/amdsmi_cli/amdsmi_commands.py
@@ -141,7 +141,7 @@ class AMDSMICommands():
             args.gpu = gpu
 
         # Handle No GPU passed
-        if args.gpu == None:
+        if args.gpu is None:
             args.gpu = self.device_handles
 
         # Handle multiple GPUs
@@ -864,15 +864,15 @@ class AMDSMICommands():
         if self.helpers.is_amd_hsmp_initialized() and self.helpers.is_amdgpu_initialized():
             # Print out all CPU and all GPU static info only if no device was specified.
             # If a GPU or CPU argument is provided only print out the specified device.
-            if args.cpu == None and args.gpu == None:
+            if args.cpu is None and args.gpu is None:
                 if not cpu_args_enabled and not gpu_args_enabled:
                     args.cpu = self.cpu_handles
                     args.gpu = self.device_handles
 
             # Handle cases where the user has only specified an argument and no specific device
-            if args.gpu == None and gpu_args_enabled:
+            if args.gpu is None and gpu_args_enabled:
                 args.gpu = self.device_handles
-            if args.cpu == None and cpu_args_enabled:
+            if args.cpu is None and cpu_args_enabled:
                 args.cpu = self.cpu_handles
 
             if args.cpu:
@@ -886,12 +886,12 @@ class AMDSMICommands():
                                     dfc_ucode, fb_info, num_vf, soc_pstate,
                                     process_isolation)
         elif self.helpers.is_amd_hsmp_initialized(): # Only CPU is initialized
-            if args.cpu == None:
+            if args.cpu is None:
                 args.cpu = self.cpu_handles
 
             self.static_cpu(args, multiple_devices, cpu, interface_ver)
         elif self.helpers.is_amdgpu_initialized(): # Only GPU is initialized
-            if args.gpu == None:
+            if args.gpu is None:
                 args.gpu = self.device_handles
 
             self.logger.clear_multiple_devices_ouput()
@@ -922,7 +922,7 @@ class AMDSMICommands():
             args.fw_list = fw_list
 
         # Handle No GPU passed
-        if args.gpu == None:
+        if args.gpu is None:
             args.gpu = self.device_handles
 
         # Handle multiple GPUs
@@ -1005,7 +1005,7 @@ class AMDSMICommands():
             args.un_res = un_res
 
         # Handle No GPU passed
-        if args.gpu == None:
+        if args.gpu is None:
             args.gpu = self.device_handles
 
         # Handle multiple GPUs
@@ -1225,7 +1225,7 @@ class AMDSMICommands():
             current_platform_values += [args.schedule, args.guard, args.guest_data, args.fb_usage, args.xgmi]
 
         # Handle No GPU passed
-        if args.gpu == None:
+        if args.gpu is None:
             args.gpu = self.device_handles
 
         # Handle watch logic, will only enter this block once
@@ -2054,7 +2054,7 @@ class AMDSMICommands():
                                     args.cpu_dimm_thermal_sensor]
 
         # Handle No CPU passed (fall back as this should be defined in metric())
-        if args.cpu == None:
+        if args.cpu is None:
             args.cpu = self.cpu_handles
 
         if not any(curr_platform_cpu_values):
@@ -2291,7 +2291,7 @@ class AMDSMICommands():
         curr_platform_core_values = [args.core_boost_limit, args.core_curr_active_freq_core_limit, args.core_energy]
 
         # Handle No cores passed
-        if args.core == None:
+        if args.core is None:
             args.core = self.core_handles
 
         if not any(curr_platform_core_values):
@@ -2469,7 +2469,7 @@ class AMDSMICommands():
             logging.debug("args.gpu: %s, args.cpu: %s, args.core: %s", args.gpu, args.cpu, args.core)
 
             # If a GPU or CPU argument is provided only print out the specified device.
-            if args.cpu == None and args.gpu == None and args.core == None:
+            if args.cpu is None and args.gpu is None and args.core is None:
                 # If no args are set, print out all CPU, GPU, and Core metrics info
                 if not gpu_args_enabled and not cpu_args_enabled and not core_args_enabled:
                     args.cpu = self.cpu_handles
@@ -2477,11 +2477,11 @@ class AMDSMICommands():
                     args.core = self.core_handles
 
             # Handle cases where the user has only specified an argument and no specific device
-            if args.gpu == None and gpu_args_enabled:
+            if args.gpu is None and gpu_args_enabled:
                 args.gpu = self.device_handles
-            if args.cpu == None and cpu_args_enabled:
+            if args.cpu is None and cpu_args_enabled:
                 args.cpu = self.cpu_handles
-            if args.core == None and core_args_enabled:
+            if args.core is None and core_args_enabled:
                 args.core = self.core_handles
 
             # Print out CPU first
@@ -2507,15 +2507,15 @@ class AMDSMICommands():
                                 xgmi_err, energy, mem_usage, schedule,
                                 guard, guest_data, fb_usage, xgmi)
         elif self.helpers.is_amd_hsmp_initialized(): # Only CPU is initialized
-            if args.cpu == None and args.core == None:
+            if args.cpu is None and args.core is None:
                 # If no args are set, print out all CPU and Core metrics info
                 if not cpu_args_enabled and not core_args_enabled:
                     args.cpu = self.cpu_handles
                     args.core = self.core_handles
 
-            if args.cpu == None and cpu_args_enabled:
+            if args.cpu is None and cpu_args_enabled:
                 args.cpu = self.cpu_handles
-            if args.core == None and core_args_enabled:
+            if args.core is None and core_args_enabled:
                 args.core = self.core_handles
 
             if args.cpu:
@@ -2531,7 +2531,7 @@ class AMDSMICommands():
                 self.metric_core(args, multiple_devices, core, core_boost_limit,
                                      core_curr_active_freq_core_limit, core_energy)
         elif self.helpers.is_amdgpu_initialized(): # Only GPU is initialized
-            if args.gpu == None:
+            if args.gpu is None:
                 args.gpu = self.device_handles
 
             self.logger.clear_multiple_devices_ouput()
@@ -2585,7 +2585,7 @@ class AMDSMICommands():
             args.iterations = iterations
 
         # Handle No GPU passed
-        if args.gpu == None:
+        if args.gpu is None:
             args.gpu = self.device_handles
 
         # Handle watch logic, will only enter this block once
@@ -2767,7 +2767,7 @@ class AMDSMICommands():
         if args.gpu:
             gpu = args.gpu
 
-        if gpu == None:
+        if gpu is None:
             args.gpu = self.device_handles
 
         if not isinstance(args.gpu, list):
@@ -2819,7 +2819,7 @@ class AMDSMICommands():
             args.numa_bw = numa_bw
 
         # Handle No GPU passed
-        if args.gpu == None:
+        if args.gpu is None:
             args.gpu = self.device_handles
 
         if not isinstance(args.gpu, list):
@@ -3166,7 +3166,7 @@ class AMDSMICommands():
         if core_boost_limit:
             args.core_boost_limit = core_boost_limit
 
-        if args.core == None:
+        if args.core is None:
             raise ValueError('No Core provided, specific Core targets(S) are needed')
 
         # Handle multiple cores
@@ -3255,7 +3255,7 @@ class AMDSMICommands():
         if soc_boost_limit:
             args.soc_boost_limit = soc_boost_limit
 
-        if args.cpu == None:
+        if args.cpu is None:
             raise ValueError('No CPU provided, specific CPU targets(S) are needed')
 
         #Handle multiple CPU's
@@ -3436,7 +3436,7 @@ class AMDSMICommands():
             args.process_isolation = process_isolation
 
         # Handle No GPU passed
-        if args.gpu == None:
+        if args.gpu is None:
             raise ValueError('No GPU provided, specific GPU target(s) are needed')
 
         # Handle multiple GPUs
@@ -3687,7 +3687,7 @@ class AMDSMICommands():
         if self.helpers.is_amd_hsmp_initialized() and self.helpers.is_amdgpu_initialized():
             # Print out all CPU and all GPU static info only if no device was specified.
             # If a GPU or CPU argument is provided only print out the specified device.
-            if args.cpu == None and args.gpu == None and args.core == None:
+            if args.cpu is None and args.gpu is None and args.core is None:
                 raise ValueError('No GPU, CPU, or CORE provided, specific target(s) are needed')
 
             if args.cpu:
@@ -3707,7 +3707,7 @@ class AMDSMICommands():
                                 memory_partition, power_cap, soc_pstate, xgmi_plpd,
                                 process_isolation)
         elif self.helpers.is_amd_hsmp_initialized(): # Only CPU is initialized
-            if args.cpu == None and args.core == None:
+            if args.cpu is None and args.core is None:
                 raise ValueError('No CPU or CORE provided, specific target(s) are needed')
             if args.cpu:
                 self.set_cpu(args, multiple_devices, cpu, cpu_pwr_limit,
@@ -3719,7 +3719,7 @@ class AMDSMICommands():
                 self.logger.clear_multiple_devices_ouput()
                 self.set_core(args, multiple_devices, core, core_boost_limit)
         elif self.helpers.is_amdgpu_initialized(): # Only GPU is initialized
-            if args.gpu == None:
+            if args.gpu is None:
                 raise ValueError('No GPU provided, specific GPU target(s) are needed')
             self.logger.clear_multiple_devices_ouput()
             self.set_gpu(args, multiple_devices, gpu, fan, perf_level,
@@ -3780,7 +3780,7 @@ class AMDSMICommands():
             args.clear_sram_data = clear_sram_data
 
         # Handle No GPU passed
-        if args.gpu == None:
+        if args.gpu is None:
             raise ValueError('No GPU provided, specific GPU target(s) are needed')
 
         # Handle multiple GPUs
@@ -4029,7 +4029,7 @@ class AMDSMICommands():
             args.pcie = pcie
 
         # Handle No GPU passed
-        if args.gpu == None:
+        if args.gpu is None:
             args.gpu = self.device_handles
 
         # If all arguments are False, the print all values
@@ -4384,7 +4384,7 @@ class AMDSMICommands():
             args.metric = metric
 
         # Handle No GPU passed
-        if args.gpu == None:
+        if args.gpu is None:
             args.gpu = self.device_handles
 
         if not isinstance(args.gpu, list):

--- a/rocm_smi/python_smi_tools/rocm_smi.py
+++ b/rocm_smi/python_smi_tools/rocm_smi.py
@@ -338,7 +338,7 @@ def getProcessName(pid):
     except subprocess.CalledProcessError as e:
         pName = 'UNKNOWN'
 
-    if pName == None:
+    if pName is None:
         pName = 'UNKNOWN'
 
     # Remove the substrings surrounding from process name (b' and \n')
@@ -1789,7 +1789,7 @@ def showAllConcise(deviceList):
         mem_use_pct = 0
         if vram_used is None:
             mem_use_pct='Unsupported'
-        if vram_used != None and vram_total != None and float(vram_total) != 0:
+        if vram_used is not None and vram_total is not None and float(vram_total) != 0:
             mem_use_pct = '% 3.0f%%' % (100 * (float(vram_used) / float(vram_total)))
 
         gpu_dev_product_info_top_name = gpu_dev_product_info_names[0]
@@ -2162,7 +2162,7 @@ def getCoarseGrainUtil(device, typeName=None):
     """
     timestamp = c_uint64(0)
 
-    if typeName != None:
+    if typeName is not None:
 
         try:
             i = utilization_counter_name.index(typeName)
@@ -3148,7 +3148,7 @@ def showWeightTopology(deviceList):
         for gpu2 in deviceList:
             if (gpu1 == gpu2):
                 printTableRow('%-12s', '0')
-            elif (gpu_links_weight[gpu1][gpu2] == None):
+            elif (gpu_links_weight[gpu1][gpu2] is None):
                 printTableRow('%-12s', 'N/A')
             else:
                 printTableRow('%-12s', gpu_links_weight[gpu1][gpu2].value)
@@ -3194,7 +3194,7 @@ def showHopsTopology(deviceList):
         for gpu2 in deviceList:
             if (gpu1 == gpu2):
                 printTableRow('%-12s', '0')
-            elif (gpu_links_hops[gpu1][gpu2] == None):
+            elif (gpu_links_hops[gpu1][gpu2] is None):
                 printTableRow('%-12s', 'N/A')
             else:
                 printTableRow('%-12s', gpu_links_hops[gpu1][gpu2].value)
@@ -3975,7 +3975,7 @@ if __name__ == '__main__':
         showPcieReplayCount(deviceList)
     if args.showserial:
         showSerialNumber(deviceList)
-    if args.showpids != None:
+    if args.showpids is not None:
         showPids(args.showpids)
     if args.showpidgpus or str(args.showpidgpus) == '[]':
         showGpusByPid(args.showpidgpus)

--- a/rocm_smi/python_smi_tools/rsmiBindings.py
+++ b/rocm_smi/python_smi_tools/rsmiBindings.py
@@ -23,7 +23,7 @@ def initRsmiBindings(silent=False):
             print(args)
 
     rocm_smi_lib_path = os.getenv('ROCM_SMI_LIB_PATH')
-    if (rocm_smi_lib_path != None):
+    if (rocm_smi_lib_path is not None):
         path_librocm = rocm_smi_lib_path
     else:
         path_librocm = os.path.dirname(os.path.realpath(__file__)) + '/../../@CMAKE_INSTALL_LIBDIR@/librocm_smi64.so.@VERSION_MAJOR@'

--- a/tools/get_platform.py
+++ b/tools/get_platform.py
@@ -70,7 +70,7 @@ if __name__ == '__main__':
             print (f)
         exit(0)
         
-    if args.diff != None:
+    if args.diff is not None:
         if args.diff[0] not in platform_map or args.diff[1] not in platform_map:
             print("Unknown platforms ", args.diff)
             exit(1)
@@ -83,7 +83,7 @@ if __name__ == '__main__':
         exit(0)
         
         
-    if args.common != None:
+    if args.common is not None:
         if args.common[0] not in platform_map or args.common[1] not in platform_map:
             print("Unknown platforms ", args.common)
             exit(1)


### PR DESCRIPTION
from PEP8 (https://peps.python.org/pep-0008/#programming-recommendations):

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.