### PR TITLE
Use correct regex to avoid SyntaxWarning: invalid escape sequence '\.'

### DIFF
--- a/amdsmi_cli/BDF.py
+++ b/amdsmi_cli/BDF.py
@@ -123,7 +123,7 @@ class BDF():
         """Overrided the 'in' comparator in python"""
         passed_bdf = str(BDF(passed_bdf))
 
-        bdf_regex = "(?:[0-6]?[0-9a-fA-F]{1,4}:)?[0-2]?[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}\.[0-7]"
+        bdf_regex = "(?:[0-6]?[0-9a-fA-F]{1,4}:)?[0-2]?[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}\\.[0-7]"
         for match in re.findall(bdf_regex, passed_bdf):
             if self == match:
                 return True

--- a/py-interface/amdsmi_interface.py
+++ b/py-interface/amdsmi_interface.py
@@ -3534,7 +3534,7 @@ def amdsmi_get_clk_freq(
     return {
         "num_supported": freq.num_supported,
         "current": freq.current,
-        "frequency": list(freq.frequency)[: freq.num_supported - 1],
+        "frequency": list(freq.frequency)[: freq.num_supported],
     }
 
 

--- a/rocm_smi/src/rocm_smi_gpu_metrics.cc
+++ b/rocm_smi/src/rocm_smi_gpu_metrics.cc
@@ -453,7 +453,7 @@ AMDGpuDynamicMetricTblValues_t format_metric_row(const T& metric, const std::str
       value = (metric);
     }
 
-    auto amdgpu_dynamic_metric_value = [&]() {
+    auto amdgpu_dynamic_metric_value = [&, data_type=data_type]() {
       AMDGpuDynamicMetricsValue_t amdgpu_dynamic_metric_value_init{};
       amdgpu_dynamic_metric_value_init.m_value = value;
       amdgpu_dynamic_metric_value_init.m_info  = (value_title + " : " + std::to_string(idx));

--- a/tools/generator.py
+++ b/tools/generator.py
@@ -111,7 +111,7 @@ def main():
 
     os_platform = platform.system()
     if os_platform == "Windows":
-        clang_include_dir += "\include"
+        clang_include_dir += "\\include"
         if "Program Files(x86)" in clang_include_dir:
             clang_include_dir = clang_include_dir.replace("Program Files(x86)", "Progra~2")
         elif "Program Files" in clang_include_dir:


### PR DESCRIPTION
Python versions prior to 3.12 may (or may not) throw `DeprecationWarning: invalid escape sequence \.`

Python 3.12 will definitely throw SyntaxWarning:
```
➜ amd-smi version
/opt/rocm-6.1.1/libexec/amdsmi_cli/BDF.py:126: SyntaxWarning: invalid escape sequence '\.'
  bdf_regex = "(?:[0-6]?[0-9a-fA-F]{1,4}:)?[0-2]?[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}\.[0-7]"
AMDSMI Tool: 24.6.0+68d8c1a-dirty | AMDSMI Library version: 24.6.0.0 | ROCm version: 6.1.1

```

