### PR TITLE
Remove `const` to avoid compile error

### DIFF
--- a/rocm_smi/include/rocm_smi/rocm_smi_utils.h
+++ b/rocm_smi/include/rocm_smi/rocm_smi_utils.h
@@ -242,7 +242,7 @@ class ScopeGuard {
   __forceinline ~ScopeGuard() {
     if (!dismiss_) release_();
   }
-  __forceinline ScopeGuard& operator=(const ScopeGuard& rhs) {
+  __forceinline ScopeGuard& operator=(ScopeGuard& rhs) {
     dismiss_ = rhs.dismiss_;
     release_ = rhs.release_;
     rhs.dismiss_ = true;


### PR DESCRIPTION
The `const` identifier prevents amdsmi to be successfully compiled as the `rhs.dismissed_` is going to be modified in this function. So remove the `const` here.