### PR TITLE
Fix typo pip install Manual/Multiple ROCm

### DIFF
--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -106,7 +106,7 @@ Python library install example for Ubuntu 22.04
             
         python3 -m pip install --upgrade pip
             
-        python3 -m pip install --user 
+        python3 -m pip install --user .
 
   
 Now you have the AMD SMI Python library in your Python path:


### PR DESCRIPTION
Hi, this is a fix for a small typo in the pip install command.

https://rocm.docs.amd.com/projects/amdsmi/en/latest/install/install.html#manual-multiple-rocm-instance-python-library-install