### PR TITLE
Using raw string for bdf_regex to suppress Python12 warning

### DIFF
--- a/amdsmi_cli/BDF.py
+++ b/amdsmi_cli/BDF.py
@@ -123,7 +123,7 @@ class BDF():
         """Overrided the 'in' comparator in python"""
         passed_bdf = str(BDF(passed_bdf))
 
-        bdf_regex = "(?:[0-6]?[0-9a-fA-F]{1,4}:)?[0-2]?[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}\\.[0-7]"
+        bdf_regex = r"(?:[0-6]?[0-9a-fA-F]{1,4}:)?[0-2]?[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}\.[0-7]"
         for match in re.findall(bdf_regex, passed_bdf):
             if self == match:
                 return True


### PR DESCRIPTION
From Python 12's release notes:
"A backslash-character pair that is not a valid escape sequence now generates a SyntaxWarning, instead of DeprecationWarning." https://docs.python.org/3/whatsnew/3.12.html#other-language-changes

When running amd-smi on systems with python 12 installed, the following warning is generated.
/opt/rocm-6.2.2/libexec/amdsmi_cli/BDF.py:126: SyntaxWarning: invalid escape sequence '\.'
  bdf_regex = "(?:[0-6]?[0-9a-fA-F]{1,4}:)?[0-2]?[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}\.[0-7]"