### PR TITLE
Golang bindings for `amdsmi_get_gpu_device_uuid`

### DIFF
--- a/goamdsmi.go
+++ b/goamdsmi.go
@@ -101,6 +101,27 @@ func GO_gpu_dev_name_get(i int) (*C.char) {
 	return C.goamdsmi_gpu_dev_name_get(C.uint(i))
 }
 
+// ``GO_gpu_dev_uuid_get`` returns the UUID of the GPU device at the specified GPU
+// index.
+//
+// Input parameter: ``int``, GPU index.
+//
+// Output: ``char*``, returns GPU UUID on success or "NA" on fail.
+//
+// Example:
+//
+//   import "github.com/ROCm/amdsmi"
+//
+//   if true == goamdsmi.GO_gpu_init() {
+//       num_gpus := int(goamdsmi.GO_gpu_num_monitor_devices())
+//       for i := 0; i < num_gpus; i++ {
+//           uuid := goamdsmi.GO_gpu_dev_uuid_get(i)
+//       }
+//   }
+func GO_gpu_dev_uuid_get(i int) (*C.char) {
+	return C.goamdsmi_gpu_dev_uuid_get(C.uint(i))
+}
+
 // ``GO_gpu_dev_id_get`` returns the device ID of the GPU device at the specified GPU
 // index.
 //

--- a/goamdsmi_shim/smiwrapper/amdsmi_go_shim.c
+++ b/goamdsmi_shim/smiwrapper/amdsmi_go_shim.c
@@ -411,6 +411,21 @@ char* goamdsmi_gpu_dev_name_get(uint32_t dv_ind)
     return dev_name;
 }
 
+char *goamdsmi_gpu_dev_uuid_get(uint32_t dv_ind)
+{
+    bool readSuccess = false;
+    uint32_t len = AMDSMI_GPU_UUID_SIZE;
+    char* dev_uuid = (char*)malloc(sizeof(char)*len);dev_uuid[0] = '\0';
+    strcpy(dev_uuid, GOAMDSMI_STRING_NA);
+
+    if((dv_ind < num_gpu_devices_inAllSocket) && (AMDSMI_STATUS_SUCCESS == amdsmi_get_gpu_device_uuid(amdsmi_processor_handle_all_gpu_device_across_socket[dv_ind], &len, dev_uuid)))
+    {
+        readSuccess = true;
+        if (enable_debug_level(GOAMDSMI_DEBUG_LEVEL_1)) {printf("AMDSMI, %s for Gpu:%d UUID:%s\n", readSuccess?"Success":"Failed", dv_ind, dev_uuid);}
+    }
+    return dev_uuid;
+}
+
 uint16_t goamdsmi_gpu_dev_id_get(uint32_t dv_ind)
 {
     bool readSuccess         = false;

--- a/goamdsmi_shim/smiwrapper/amdsmi_go_shim.h
+++ b/goamdsmi_shim/smiwrapper/amdsmi_go_shim.h
@@ -217,6 +217,24 @@ uint32_t goamdsmi_gpu_num_monitor_devices();
  */
 char* goamdsmi_gpu_dev_name_get(uint32_t dv_ind);
 
+
+/**
+ *  @brief Go language stub to get the gpu device UUID string
+ *
+ *  @details This function will call the amdsmi_get_gpu_device_uuid()
+ *  function to write the gpu device UUID string (up to len characters)
+ *  for device dv_ind and return a char pointer. This value is then
+ *  passed as char * to the Go routine that called it. The caller of this
+ *  function must free the allocated buffer for the device name.
+ *
+ *  @param[in] ::uint32_t device index
+ *
+ *  @retval ::char* UUID
+ *  @retval NA is returned upon failure.
+ *
+ */
+char *goamdsmi_gpu_dev_uuid_get(uint32_t dv_ind);
+
 /**
  *  @brief Go language stub to get the GPU device id
  *


### PR DESCRIPTION
It seemed that the go library was missing a way to get the UUID of devices. This PR adds bindings for that, following the style of the existing functions in `goamdsmi.go` and the `_shim` files.