### PR TITLE
Exposed the energy count and current socket power metrics to profilers like PAPI

### DIFF
--- a/rocm_smi/src/rocm_smi_device.cc
+++ b/rocm_smi/src/rocm_smi_device.cc
@@ -585,6 +585,9 @@ static const std::map<const char *, dev_depends_t> kDevFuncDependsMap = {
   {"rsmi_dev_memory_reserved_pages_get", {{kDevMemPageBadFName}, {}}},
   {"rsmi_topo_numa_affinity_get",        {{kDevNumaNodeFName}, {}}},
   {"rsmi_dev_gpu_metrics_info_get",      {{kDevGpuMetricsFName}, {}}},
+  {"rsmi_dev_energy_count_get",          {{kDevGpuMetricsFName}, {}}},
+  {"rsmi_dev_current_socket_power_get",  {{kDevGpuMetricsFName}, {}}},
+
   {"rsmi_dev_pm_metrics_info_get",       {{kDevPmMetricsFName}, {}}},
   {"rsmi_dev_reg_table_info_get",        {{kDevRegMetricsFName}, {}}},
   {"rsmi_dev_gpu_reset",                 {{kDevGpuResetFName}, {}}},


### PR DESCRIPTION
Added 2 lines that allow PAPI (https://github.com/icl-utk-edu/papi) to profile the energy and current socket power, for HPC research.

It simply adds the two functions `rsmi_dev_energy_count_get` and `rsmi_dev_current_socket_power_get` to the device function dependency map.