### PR TITLE
Fix double free error when used with PyTorch

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,16 @@ set(${AMD_SMI}_VERSION_BUILD "0")
 message("SOVERSION: ${SO_VERSION_STRING}")
 
 add_library(${AMD_SMI} ${SRC_LIST} ${INC_LIST})
+
+# Add symbol versioning and isolation to prevent conflicts with torch's ROCm SMI
+# This solves the double-free issue when both libraries are loaded
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set_target_properties(${AMD_SMI} PROPERTIES
+        LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/amdsmi_symbols.map"
+        LINK_FLAGS_RELEASE "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/amdsmi_symbols.map"
+    )
+endif()
+
 target_link_libraries(${AMD_SMI} pthread rt dl ${DRM_LIBRARIES} ${AMDGPU_DRM_LIBRARIES})
 target_include_directories(${AMD_SMI} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/rocm_smi/include
                                               ${PROJECT_SOURCE_DIR}/common/shared_mutex ${ACA_INC_DIR})

--- a/src/amdsmi_symbols.map
+++ b/src/amdsmi_symbols.map
@@ -1,0 +1,21 @@
+AMDSMI_1.0 {
+  global:
+    # Export only amdsmi public API functions
+    amdsmi_*;
+    
+  local:
+    # Hide all internal symbols to prevent conflicts with torch's ROCm SMI
+    # This includes all amd::smi namespace symbols that conflict with torch
+    _ZN3amd3smi*;
+    _ZN*amd*smi*;
+    _ZNK*amd*smi*;
+    _ZTI*amd*smi*;
+    _ZTS*amd*smi*;
+    _ZTV*amd*smi*;
+    
+    # Hide ROCm SMI symbols
+    rsmi_*;
+    
+    # Hide all other internal symbols
+    *;
+};


### PR DESCRIPTION
I was trying to use amdsmi in vllm and noticed that if I import torch after installing amdsmi I would always get a double free error thrown on exit if I imported torch, this was also raised in:

- https://github.com/ROCm/TheRock/issues/1059

I want to avoid this issue surfacing in future.

## Technical Details

Both us and torch ship their own ROCm SMI libraries:
- /opt/venv/.../amdsmi/libamd_smi.so (ours)
- /opt/venv/.../librocm_smi64.so.7 (torch's)

Same exact symbols exported by both:
_ZN3amd3smi6Device11readDevInfoE...
_ZN3amd3smi14GetDevValueVecE...

They're using identical amd::smi namespaces and class definitions. 

How I figured this out:

Simple test showed the import order dependency:
python3 -c "import torch; import amdsmi"  <-- crashes every time
python3 -c "import amdsmi; import torch"  <-- works perfectly

GDB pointed me to the real culprit:
#6 ... std::map<amd::smi::DevInfoTypes, char const*>::~map()
   from /opt/venv/.../librocm_smi64.so.7

Added symbol versioning with a linker script to hide the amdsmi internal ROCm symbols. Now only public amdsmi_* API functions are visible to other libraries, while all the internal ROCm stuff stays private. This resolves symbol collision between amdsmi and PyTorch's ROCm SMI libraries that caused 'double free or corruption (!prev)' during Python exit.

- Add symbol versioning to hide internal amd::smi symbols
- Export only public amdsmi_* API functions
- Prevent symbol collision with other ROCm SMI implementations
- Use standard Linux linker script approach for symbol isolation

Tested: python3 -c 'import torch' now works without crash
