### PR TITLE
Fix a crash when running `amd-smi version --cpu`

### DIFF
--- a/src/amd_smi/amd_smi.cc
+++ b/src/amd_smi/amd_smi.cc
@@ -6317,6 +6317,8 @@ amdsmi_status_t amdsmi_get_cpu_handles(uint32_t *cpu_count,
                                                       nullptr, &cpu_per_soc);
         if (status != AMDSMI_STATUS_SUCCESS)
             return status;
+        if (cpu_per_soc == 0)
+            continue;
 
         // Allocate the memory for the cpus
         std::vector<amdsmi_processor_handle> plist(cpu_per_soc);


### PR DESCRIPTION
## Motivation

When running on a system that doesn't support HSMP (such as an APU) then the following is observed:
```
/usr/include/c++/15.1.1/bits/stl_vector.h:1263: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](size_type) [with _Tp = void*; _Alloc = std::allocator<void*>; reference = void*&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
```

## Technical Details

This is because no "CPU" are detected on the SOC, which really means no CPUs that support HSMP.  Catch this case so that a clean return can be passed up.

## Test Plan

Run `amd-smi version -c` on a system without HSMP.

## Test Result

No longer crashes

```sh
❯ amd-smi version -c
AMDSMI Tool: 26.1.0+969c1758 | AMDSMI Library version: 26.1.0 | ROCm version: N/A | amd_hsmp version: N/A
```
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
