### PR TITLE
Stop trying to fit too much in one line for default view

### DIFF
--- a/amdsmi_cli/amdsmi_logger.py
+++ b/amdsmi_cli/amdsmi_logger.py
@@ -1030,7 +1030,8 @@ class AMDSMILogger():
         print(default_line_1)
         # Split the version line into 3 lines, each wrapping to the same width
         print("| AMD-SMI {0:40s} {1:28s}|".format(amd_smi_version.ljust(40), ""))
-        print("| amdgpu version: {0:40s} {1:20s}|".format(amdgpu_version.ljust(40), ""))
+        if amdgpu_version != "N/A":
+            print("| amdgpu version: {0:40s} {1:20s}|".format(amdgpu_version.ljust(40), ""))
         if rocm_version != "N/A":
             print("| ROCm version:   {0:40s} {1:28s}|".format(rocm_version.ljust(40), ""))
 

--- a/amdsmi_cli/amdsmi_logger.py
+++ b/amdsmi_cli/amdsmi_logger.py
@@ -1028,7 +1028,11 @@ class AMDSMILogger():
 
         # print GPU info
         print(default_line_1)
-        print("| AMD-SMI {0:20s} amdgpu version: {1:8s} ROCm version: {2:8s} |".format(amd_smi_version.ljust(20), amdgpu_version, rocm_version))
+        # Split the version line into 3 lines, each wrapping to the same width
+        print("| AMD-SMI {0:40s} {1:28s}|".format(amd_smi_version.ljust(40), ""))
+        print("| amdgpu version: {0:40s} {1:20s}|".format(amdgpu_version.ljust(40), ""))
+        if rocm_version != "N/A":
+            print("| ROCm version:   {0:40s} {1:28s}|".format(rocm_version.ljust(40), ""))
 
         # adjust format depending on whether vbios or fw pldm version is present
         if vbios_version != "N/A" and fw_pldm_version != "N/A":

--- a/src/amd_smi/amd_smi.cc
+++ b/src/amd_smi/amd_smi.cc
@@ -4433,6 +4433,9 @@ amdsmi_status_t amdsmi_get_gpu_driver_info(amdsmi_processor_handle processor_han
     // Get the driver version
     status = smi_amdgpu_get_driver_version(gpu_device,
                 &length, info->driver_version);
+    if (status != AMDSMI_STATUS_SUCCESS) {
+        return status;
+    }
 
     SMIGPUDEVICE_MUTEX(gpu_device->get_mutex())
     std::string render_name = gpu_device->get_gpu_path();

--- a/src/amd_smi/amd_smi_utils.cc
+++ b/src/amd_smi/amd_smi_utils.cc
@@ -617,12 +617,9 @@ amdsmi_status_t smi_amdgpu_get_driver_version(amd::smi::AMDSmiGPUDevice* device,
     std::strncpy(version, empty.c_str(), len-1);
     openFileAndModifyBuffer("/sys/module/amdgpu/version",
                                       version, static_cast<size_t>(len));
-    if (version[0] == '\0') {
-        openFileAndModifyBuffer("/proc/version", version, static_cast<size_t>(len));
-        if (version[0] == '\0') {
-            return AMDSMI_STATUS_IO;
-        }
-    }
+    if (version[0] == '\0')
+        return AMDSMI_STATUS_DIRECTORY_NOT_FOUND;
+
     return status;
 }
 


### PR DESCRIPTION
## Motivation
The default view is really cramped trying to put a lot of version information into one line, to the point that some strings are cropped. 

## Technical Details

Instead of cropping the strings just put each into it's own line.
For running without a ROCm release installed hide the ROCm version line.

## Test Plan

Run the tool and look at output.

## Test Result

Sample output:
```
+------------------------------------------------------------------------------+
| AMD-SMI 26.1.0+2a668c34                                                      |
| amdgpu version: Linuxver                                                     |
| VBIOS version: 023.010.001.022.000001                                        |
| Platform: Linux Baremetal                                                    |
|-------------------------------------+----------------------------------------|
| BDF                        GPU-Name | Mem-Uti   Temp   UEC       Power-Usage |
| GPU  HIP-ID  OAM-ID  Partition-Mode | GFX-Uti    Fan               Mem-Usage |
|=====================================+========================================|
| 0000:c1:00.0 ...adeon 890M Graphics | N/A      59 °C   0                17 W |
|   0       0     N/A             N/A | 25 %       N/A              479/512 MB |
+-------------------------------------+----------------------------------------+
+------------------------------------------------------------------------------+
| Processes:                                                                   |
|  GPU        PID  Process Name          GTT_MEM  VRAM_MEM  MEM_USAGE     CU % |
|==============================================================================|
|  No running processes found                                                  |
+------------------------------------------------------------------------------+
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
