### PR TITLE
cmake: build: fix SOVERSION variable scoping issue on fallback

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,11 @@ if(ENABLE_ESMI_LIB)
 endif()
 # VERSION_* variables should be set by get_version_from_tag
 message("Package version: ${PKG_VERSION_STR}")
+# There is variable scoping problem where we lost values set in parent CMakeLists
+# setting them back
+set(${AMD_SMI_LIBS_TARGET}_VERSION_MAJOR "${CPACK_PACKAGE_VERSION_MAJOR}")
+set(${AMD_SMI_LIBS_TARGET}_VERSION_MINOR "${CPACK_PACKAGE_VERSION_MINOR}")
+set(${AMD_SMI_LIBS_TARGET}_VERSION_PATCH "${CPACK_PACKAGE_VERSION_PATCH}")
 
 # Debian package specific variables
 # Set a default value for the package version


### PR DESCRIPTION
## Technical Details

While packaging amdsmi for debian, I realized that it actually fallbacks to 0.0 instead of 25.5 in my case. So I re-initialize the variables used for fallback here in the child CMakeLists file as in the root CMakeLists file.

Not exactly sure if this is a correct way to fix scoping problem but this fixes the packaging and fallback works as expected when there is no .git available in build environment.

## Test Plan

Go to https://code.launchpad.net/~bullwinkle-team/ubuntu/+source/amdsmi/+git/amdsmi/+ref/bullwinkle/ubuntu/devel and the clone the repo using `bullwinkle/ubuntu/devel` branch which should have debian packaging files already in. Put this patch (https://patch-diff.githubusercontent.com/raw/ROCm/amdsmi/pull/127.patch) in PR into debian/patches/ and add the file name into debian/series

Then start your build what ever tool you would like to use, I prefer `sbuild`

## Test Result

```
drwxr-xr-x root/root         0 2025-09-03 19:28 ./
drwxr-xr-x root/root         0 2025-09-03 19:28 ./usr/
drwxr-xr-x root/root         0 2025-09-03 19:28 ./usr/lib/
drwxr-xr-x root/root         0 2025-09-03 19:28 ./usr/lib/x86_64-linux-gnu/
lrwxrwxrwx root/root         0 2025-09-03 19:28 ./usr/lib/x86_64-linux-gnu/libamd_smi.so.25 -> libamd_smi.so.25.5
-rw-r--r-- root/root   2125088 2025-09-03 19:28 ./usr/lib/x86_64-linux-gnu/libamd_smi.so.25.5
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
