### PR TITLE
[cmake] Fix dependencies.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,11 +116,49 @@ set(CPACK_PACKAGE_CONTACT "AMD-SMILib Support <amd-smi.support@amd.com>" CACHE S
 
 generic_package()
 
-## Dependencies
+# Dependencies
 find_package(Threads REQUIRED)
 pkg_check_modules(DRM REQUIRED IMPORTED_TARGET libdrm)
 pkg_check_modules(DRM_AMDGPU REQUIRED IMPORTED_TARGET libdrm_amdgpu)
 
+# Configuration
+function(get_imported_soname target out_var)
+    get_target_property(link_libs ${target} INTERFACE_LINK_LIBRARIES)
+    set(result)
+    foreach(link_lib ${link_libs})
+        if(result)
+            message(FATAL_ERROR "Target ${target} has multiple link libraries: ${link_libs}")
+        endif()
+        execute_process(
+            COMMAND objdump -p "${link_lib}"
+            OUTPUT_VARIABLE OBJDUMP_OUTPUT
+            RESULT_VARIABLE OBJDUMP_RESULT
+        )
+        if(OBJDUMP_RESULT EQUAL 0)
+            string(REGEX MATCH "SONAME +([^ \n]+)" SONAME_MATCH "${OBJDUMP_OUTPUT}")
+            if(SONAME_MATCH)
+                set(SONAME_OF_MY_PKG "${CMAKE_MATCH_1}")
+                message(STATUS "SONAME of my_package_name: ${SONAME_OF_MY_PKG}")
+            else()
+                message(FATAL_ERROR "Could not find SONAME in objdump output for ${link_lib}")
+            endif()
+            set(result "${SONAME_OF_MY_PKG}")
+        else()
+            message(FATAL_ERROR "objdump failed for ${link_lib}")
+        endif()
+    endforeach()
+    if(NOT result)
+        message(FATAL_ERROR "Could not find SONAME for target ${target} libs: ${link_libs}")
+    endif()
+    set("${out_var}" "${result}" PARENT_SCOPE)
+endfunction()
+
+get_imported_soname(PkgConfig::DRM_AMDGPU LIBDRM_AMDGPU_SONAME)
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/config/amd_smi_config.h.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/include/config/amd_smi_config.h"
+    @ONLY
+)
 
 ## Compiler flags
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -fno-rtti")
@@ -190,8 +228,13 @@ if(ENABLE_ESMI_LIB)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-write-strings")
 endif()
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/third_party/shared_mutex
-                    ${CMAKE_CURRENT_SOURCE_DIR}/include/amd_smi ${ESMI_INC_DIR})
+include_directories(
+    ${CMAKE_CURRENT_SOURCE_DIR}/include 
+    ${CMAKE_CURRENT_BINARY_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/third_party/shared_mutex                
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/amd_smi 
+    ${ESMI_INC_DIR}
+)
 
 set(CMN_SRC_LIST
     "${ROCM_SRC_DIR}/rocm_smi_device.cc"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,12 @@ set(CPACK_PACKAGE_CONTACT "AMD-SMILib Support <amd-smi.support@amd.com>" CACHE S
 
 generic_package()
 
+## Dependencies
+find_package(Threads REQUIRED)
+pkg_check_modules(DRM REQUIRED IMPORTED_TARGET libdrm)
+pkg_check_modules(DRM_AMDGPU REQUIRED IMPORTED_TARGET libdrm_amdgpu)
+
+
 ## Compiler flags
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -fno-rtti")
 if(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "x86_64")

--- a/include/config/amd_smi_config.h.in
+++ b/include/config/amd_smi_config.h.in
@@ -1,0 +1,4 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+
+#define LIBDRM_AMDGPU_SONAME "@LIBDRM_AMDGPU_SONAME@"

--- a/rocm_smi/CMakeLists.txt
+++ b/rocm_smi/CMakeLists.txt
@@ -47,13 +47,15 @@ configure_file("src/${ROCM_SMI_TARGET}Config.in"
 add_library(${ROCM_SMI_TARGET} ${CMN_SRC_LIST} ${CMN_INC_LIST})
 target_link_libraries(${ROCM_SMI_TARGET} PRIVATE
     rt
-    PkgConfig::DRM
-    PkgConfig::DRM_AMDGPU
     Threads::Threads
     ${CMAKE_DL_LIBS}
 )
-target_include_directories(${ROCM_SMI_TARGET} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-                                                      ${PROJECT_SOURCE_DIR}/common/shared_mutex)
+target_include_directories(${ROCM_SMI_TARGET} PRIVATE 
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/common/shared_mutex
+    ${DRM_INCLUDE_DIRS}
+    ${DRM_AMDGPU_INCLUDE_DIRS}
+)
 
 # use the target_include_directories() command to specify the include directories for the target
 target_include_directories(${ROCM_SMI_TARGET} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"

--- a/rocm_smi/CMakeLists.txt
+++ b/rocm_smi/CMakeLists.txt
@@ -45,7 +45,12 @@ configure_file("src/${ROCM_SMI_TARGET}Config.in"
                "${CMAKE_CURRENT_SOURCE_DIR}/include/rocm_smi/${ROCM_SMI_TARGET}Config.h")
 
 add_library(${ROCM_SMI_TARGET} ${CMN_SRC_LIST} ${CMN_INC_LIST})
-target_link_libraries(${ROCM_SMI_TARGET} PRIVATE pthread rt dl)
+target_link_libraries(${ROCM_SMI_TARGET} PRIVATE 
+    PkgConfig::DRM
+    PkgConfig::DRM_AMDGPU
+    Threads::Threads
+    ${CMAKE_DL_LIBS}
+)
 target_include_directories(${ROCM_SMI_TARGET} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
                                                       ${PROJECT_SOURCE_DIR}/common/shared_mutex)
 

--- a/rocm_smi/CMakeLists.txt
+++ b/rocm_smi/CMakeLists.txt
@@ -45,7 +45,8 @@ configure_file("src/${ROCM_SMI_TARGET}Config.in"
                "${CMAKE_CURRENT_SOURCE_DIR}/include/rocm_smi/${ROCM_SMI_TARGET}Config.h")
 
 add_library(${ROCM_SMI_TARGET} ${CMN_SRC_LIST} ${CMN_INC_LIST})
-target_link_libraries(${ROCM_SMI_TARGET} PRIVATE 
+target_link_libraries(${ROCM_SMI_TARGET} PRIVATE
+    rt
     PkgConfig::DRM
     PkgConfig::DRM_AMDGPU
     Threads::Threads

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,13 +80,17 @@ message("SOVERSION: ${SO_VERSION_STRING}")
 add_library(${AMD_SMI} ${SRC_LIST} ${INC_LIST})
 target_link_libraries(${AMD_SMI} PRIVATE
     rt
-    PkgConfig::DRM
-    PkgConfig::DRM_AMDGPU
     Threads::Threads
     ${CMAKE_DL_LIBS}
 )
-target_include_directories(${AMD_SMI} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/rocm_smi/include
-                                              ${PROJECT_SOURCE_DIR}/common/shared_mutex ${ACA_INC_DIR})
+target_include_directories(${AMD_SMI} PRIVATE 
+    ${CMAKE_CURRENT_SOURCE_DIR} 
+    ${PROJECT_SOURCE_DIR}/rocm_smi/include
+    ${PROJECT_SOURCE_DIR}/common/shared_mutex 
+    ${ACA_INC_DIR}
+    ${DRM_INCLUDE_DIRS}
+    ${DRM_AMDGPU_INCLUDE_DIRS}                                          
+)
 
 # use the target_include_directories() command to specify the include directories for the target
 target_include_directories(${AMD_SMI} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,7 +78,12 @@ set(${AMD_SMI}_VERSION_BUILD "0")
 message("SOVERSION: ${SO_VERSION_STRING}")
 
 add_library(${AMD_SMI} ${SRC_LIST} ${INC_LIST})
-target_link_libraries(${AMD_SMI} pthread rt dl ${DRM_LIBRARIES} ${AMDGPU_DRM_LIBRARIES})
+target_link_libraries(${AMD_SMI} PRIVATE
+    PkgConfig::DRM
+    PkgConfig::DRM_AMDGPU
+    Threads::Threads
+    ${CMAKE_DL_LIBS}
+)
 target_include_directories(${AMD_SMI} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/rocm_smi/include
                                               ${PROJECT_SOURCE_DIR}/common/shared_mutex ${ACA_INC_DIR})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,6 +79,7 @@ message("SOVERSION: ${SO_VERSION_STRING}")
 
 add_library(${AMD_SMI} ${SRC_LIST} ${INC_LIST})
 target_link_libraries(${AMD_SMI} PRIVATE
+    rt
     PkgConfig::DRM
     PkgConfig::DRM_AMDGPU
     Threads::Threads

--- a/src/amd_smi/amd_smi.cc
+++ b/src/amd_smi/amd_smi.cc
@@ -45,6 +45,7 @@
 #include <functional>
 #include <exception>
 
+#include "config/amd_smi_config.h"
 #include "amd_smi/amdsmi.h"
 #include "amd_smi/impl/fdinfo.h"
 #include "amd_smi/impl/amd_smi_common.h"
@@ -924,11 +925,11 @@ amdsmi_status_t amdsmi_get_gpu_vram_usage(amdsmi_processor_handle processor_hand
     }
 
     amd::smi::AMDSmiLibraryLoader libdrm;
-    amdsmi_status_t status = libdrm.load("libdrm.so.2");
+    amdsmi_status_t status = libdrm.load(LIBDRM_AMDGPU_SONAME);
     if (status != AMDSMI_STATUS_SUCCESS) {
         libdrm.unload();
         ss << __PRETTY_FUNCTION__
-           << " | Failed to load libdrm.so.2: " << strerror(errno)
+           << " | Failed to load " LIBDRM_AMDGPU_SONAME ": " << strerror(errno)
            << "; Returning: " << smi_amdgpu_get_status_string(status, false);
         LOG_ERROR(ss);
         return status;
@@ -1730,11 +1731,11 @@ amdsmi_get_gpu_asic_info(amdsmi_processor_handle processor_handle, amdsmi_asic_i
     }
 
     amd::smi::AMDSmiLibraryLoader libdrm;
-    status = libdrm.load("libdrm.so.2");
+    status = libdrm.load(LIBDRM_AMDGPU_SONAME);
     if (status != AMDSMI_STATUS_SUCCESS) {
         libdrm.unload();
         ss << __PRETTY_FUNCTION__
-           << " | Failed to load libdrm.so.2: " << strerror(errno)
+           << " | Failed to load " LIBDRM_AMDGPU_SONAME ": " << strerror(errno)
            << "; Returning: " << smi_amdgpu_get_status_string(status, false);
         LOG_ERROR(ss);
         return status;
@@ -1953,11 +1954,11 @@ amdsmi_status_t amdsmi_get_gpu_vram_info(
     }
 
     amd::smi::AMDSmiLibraryLoader libdrm;
-    amdsmi_status_t status = libdrm.load("libdrm.so.2");
+    amdsmi_status_t status = libdrm.load(LIBDRM_AMDGPU_SONAME);
     if (status != AMDSMI_STATUS_SUCCESS) {
         libdrm.unload();
         ss << __PRETTY_FUNCTION__
-           << " | Failed to load libdrm.so.2: " << strerror(errno)
+           << " | Failed to load " LIBDRM_AMDGPU_SONAME ": " << strerror(errno)
            << "; Returning: " << smi_amdgpu_get_status_string(status, false);
         LOG_ERROR(ss);
         return status;
@@ -3880,11 +3881,11 @@ amdsmi_get_gpu_vbios_info(amdsmi_processor_handle processor_handle, amdsmi_vbios
     }
 
     amd::smi::AMDSmiLibraryLoader libdrm;
-    status = libdrm.load("libdrm.so.2");
+    status = libdrm.load(LIBDRM_AMDGPU_SONAME);
     if (status != AMDSMI_STATUS_SUCCESS) {
         libdrm.unload();
         ss << __PRETTY_FUNCTION__
-           << " | Failed to load libdrm.so.2: " << strerror(errno)
+           << " | Failed to load " LIBDRM_AMDGPU_SONAME ": " << strerror(errno)
            << "; Returning: " << smi_amdgpu_get_status_string(status, false);
         LOG_ERROR(ss);
         return status;
@@ -4456,11 +4457,11 @@ amdsmi_status_t amdsmi_get_gpu_driver_info(amdsmi_processor_handle processor_han
         return AMDSMI_STATUS_FILE_ERROR;
     }
     amd::smi::AMDSmiLibraryLoader libdrm;
-    status = libdrm.load("libdrm.so.2");
+    status = libdrm.load(LIBDRM_AMDGPU_SONAME);
     if (status != AMDSMI_STATUS_SUCCESS) {
         libdrm.unload();
         ss << __PRETTY_FUNCTION__
-           << " | Failed to load libdrm.so.2"
+           << " | Failed to load " LIBDRM_AMDGPU_SONAME ": " << strerror(errno)
            << "; Returning: " << smi_amdgpu_get_status_string(status, false);
         LOG_ERROR(ss);
         return status;
@@ -4933,11 +4934,11 @@ amdsmi_get_gpu_virtualization_mode(amdsmi_processor_handle processor_handle,
     }
 
     amd::smi::AMDSmiLibraryLoader libdrm;
-    status = libdrm.load("libdrm.so.2");
+    status = libdrm.load(LIBDRM_AMDGPU_SONAME);
     if (status != AMDSMI_STATUS_SUCCESS) {
         libdrm.unload();
         ss << __PRETTY_FUNCTION__
-           << " | Failed to load libdrm.so.2"
+           << " | Failed to load " LIBDRM_AMDGPU_SONAME ": " << strerror(errno)
            << "; Returning: " << smi_amdgpu_get_status_string(status, false);
         LOG_ERROR(ss);
         return status;

--- a/src/amd_smi/amd_smi_utils.cc
+++ b/src/amd_smi/amd_smi_utils.cc
@@ -45,6 +45,7 @@
 #include <regex>
 #include <sstream>
 
+#include "config/amd_smi_config.h"
 #include "amd_smi/impl/amd_smi_utils.h"
 #include "amd_smi/impl/amd_smi_system.h"
 #include "shared_mutex.h"  // NOLINT
@@ -680,7 +681,7 @@ amdsmi_status_t smi_amdgpu_get_market_name_from_dev_id(amd::smi::AMDSmiGPUDevice
     }
 
     amd::smi::AMDSmiLibraryLoader libdrm_amdgpu_;
-    amdsmi_status_t status = libdrm_amdgpu_.load("libdrm_amdgpu.so");
+    amdsmi_status_t status = libdrm_amdgpu_.load(LIBDRM_AMDGPU_SONAME);
     if (status != AMDSMI_STATUS_SUCCESS) {
       libdrm_amdgpu_.unload();
       return status;


### PR DESCRIPTION
* Use CMAKE_DL_LIBS instead of hard-coded `dl`.
* Use Threads::Threads instead of `pthread`.
* Find libdrm via pkgconfig (consistent to how other ROCm projects do it as documented here: https://github.com/ROCm/TheRock/blob/main/docs/development/dependencies.md#libdrm)
* Discovers the SONAME of libdrm_amdgpu used to build (and that matches headers) and puts this in a new config header so that it can be used by dlopen instead of the generic "libdrm_amdgpu.so" (which could be anything and is only guaranteed available in some cases with dev packages installed).