### PR TITLE
Fix #132: Python parser not accepting compute partition arguments

### DIFF
--- a/amdsmi_cli/amdsmi_helpers.py
+++ b/amdsmi_cli/amdsmi_helpers.py
@@ -779,9 +779,8 @@ class AMDSMIHelpers():
             logging.debug("AMDSMIHelpers.get_accelerator_choices_types_indices - Root, getting accelerator partition profiles")
         accelerator_partition_profiles = self.get_accelerator_partition_profile_config()
         if len(accelerator_partition_profiles['profile_types']) != 0:
-            compute_partitions_str = accelerator_partition_profiles['profile_types'] + accelerator_partition_profiles['profile_indices']
-            accelerator_choices = ", ".join(compute_partitions_str)
-            return_val = (accelerator_choices, accelerator_partition_profiles)
+            compute_partitions_list = accelerator_partition_profiles['profile_types'] + accelerator_partition_profiles['profile_indices']
+            return_val = (compute_partitions_list, accelerator_partition_profiles)
         return return_val
 
 

--- a/amdsmi_cli/amdsmi_parser.py
+++ b/amdsmi_cli/amdsmi_parser.py
@@ -1227,7 +1227,8 @@ class AMDSMIParser(argparse.ArgumentParser):
                 set_perf_det_help = f"Set performance determinism and select one of the corresponding performance levels:\n\t{perf_det_choices_str}"
                 (accelerator_set_choices, _) = self.helpers.get_accelerator_choices_types_indices()
                 memory_partition_choices_str = ", ".join(self.helpers.get_memory_partition_types())
-                set_compute_partition_help = f"Set one of the following the accelerator TYPE or profile INDEX:\n\t{accelerator_set_choices}.\n\tUse `sudo amd-smi partition --accelerator` to find acceptable values."
+                accelerator_set_choices_str = ", ".join(accelerator_set_choices)
+                set_compute_partition_help = f"Set one of the following the accelerator TYPE or profile INDEX:\n\t{accelerator_set_choices_str}.\n\tUse `sudo amd-smi partition --accelerator` to find acceptable values."
                 set_memory_partition_help = f"Set one of the following the memory partition modes:\n\t{memory_partition_choices_str}"
                 soc_pstate_help_info = ", ".join(self.helpers.get_soc_pstates())
                 set_soc_pstate_help = f"Set the GPU soc pstate policy using policy id, an integer. Valid id's include:\n\t{soc_pstate_help_info}"


### PR DESCRIPTION
Fixes #132

The argparse 'choices' parameter was receiving a comma-separated string instead of a list, causing it to treat individual characters as valid choices rather than complete tokens like 'SPX', 'DPX', etc.

Fixed by removing the unnecessary join() operation in `get_accelerator_choices_types_indices()` to return the list directly. This matches the pattern used by `get_memory_partition_types()`.

Now `amd-smi set -C DPX` and other partition commands work correctly.

## Motivation

Issue #132 reported that compute partition commands like `amd-smi set -C DPX` were failing with argparse errors. MI300X users were unable to configure their GPU compute partitions (SPX/DPX/QPX/CPX modes) through the CLI, blocking a core functionality for multi-instance GPU configurations.

## Technical Details

**Root Cause:** In amdsmi_helpers.py, the `get_accelerator_choices_types_indices()` function was converting the list of valid partition types to a comma-separated string using `", ".join()` before returning it to the argument parser.

**Fix:** Removed the join operation on line 783 and returned the list directly. This aligns with how `get_memory_partition_types()` handles similar data.

**Changed File:** amdsmi_helpers.py (lines 782-784)
- Before: `accelerator_choices = ", ".join(compute_partitions_str)`
- After: Returns `compute_partitions_list` directly as a list

**Impact:** The parser in `amdsmi_parser.py` (line 1279) now receives a proper list for argparse's `choices` parameter, allowing it to validate complete tokens instead of individual characters.

## Test Plan

Tested on a system with MI300X GPU support:
1. Verified `amd-smi set -C DPX` command executes without argparse errors
2. Confirmed all partition types are accepted: SPX, DPX, QPX, CPX
3. Verified partition index arguments (0, 1, 2, 3) work correctly
4. Checked that invalid inputs are properly rejected by argparse

## Test Result

All compute partition commands now work as expected. The argparse validation correctly accepts valid partition types and indices while rejecting invalid inputs. The fix resolves the reported issue without affecting other functionality.
