### PR TITLE
Stop trying to fit too much in one line for default view

### DIFF
--- a/amdsmi_cli/amdsmi_logger.py
+++ b/amdsmi_cli/amdsmi_logger.py
@@ -1029,23 +1029,19 @@ class AMDSMILogger():
         # print GPU info
         print(default_line_1)
         # Split the version line into 3 lines, each wrapping to the same width
-        print("| AMD-SMI {0:40s} {1:28s}|".format(amd_smi_version.ljust(40), ""))
+        print("| AMD-SMI          {0:40s} {1:19s}|".format(amd_smi_version.ljust(40), ""))
         if amdgpu_version != "N/A":
-            print("| amdgpu version: {0:40s} {1:20s}|".format(amdgpu_version, ""))
+            print("| amdgpu Version:  {0:40s} {1:19s}|".format(amdgpu_version, ""))
         if rocm_version != "N/A":
-            print("| ROCm version:   {0:40s} {1:28s}|".format(rocm_version, ""))
+            print("| ROCm Version:    {0:40s} {1:19s}|".format(rocm_version, ""))
 
-        # adjust format depending on whether vbios or fw pldm version is present
-        if vbios_version != "N/A" and fw_pldm_version != "N/A":
-            print("| VBIOS version: {0:22s}  {1:12s}  FW PLDM: {2:15s}|".format(vbios_version, "", fw_pldm_version))
-        elif vbios_version != "N/A" and fw_pldm_version == "N/A":
-            print("| VBIOS version: {0:22s}  {1:37s} |".format(vbios_version, ""))
-        elif fw_pldm_version != "N/A" and vbios_version == "N/A":
-            print("| FW PLDM: {0:15s}  {1:50s} |".format(fw_pldm_version, ""))
-        else:
-            pass  # Both VBIOS and FW PLDM versions are "N/A" so skip this line
+        # only print if the version is not "N/A"
+        if vbios_version != "N/A":
+            print("| VBIOS Version:   {0:22s}  {1:35s} |".format(vbios_version, ""))
+        if fw_pldm_version != "N/A":
+            print("| FW PLDM:         {0:15s}  {1:42s} |".format(fw_pldm_version, ""))
 
-        print("| Platform: {0:25.25s} {1:41s}|".format(str(self.helpers.os_info()), ""))
+        print("| Platform:        {0:25.25s} {1:34s}|".format(str(self.helpers.os_info()), ""))
         print(default_line_2)
         print("| BDF                        GPU-Name | Mem-Uti   Temp   UEC       Power-Usage |")
         print("| GPU  HIP-ID  OAM-ID  Partition-Mode | GFX-Uti    Fan               Mem-Usage |")

--- a/amdsmi_cli/amdsmi_logger.py
+++ b/amdsmi_cli/amdsmi_logger.py
@@ -1030,7 +1030,8 @@ class AMDSMILogger():
         print(default_line_1)
         # Split the version line into 3 lines, each wrapping to the same width
         print("| AMD-SMI {0:40s} {1:28s}|".format(amd_smi_version.ljust(40), ""))
-        print("| amdgpu version: {0:40s} {1:20s}|".format(amdgpu_version.ljust(40), ""))
+        if amdgpu_version != "N/A":
+            print("| amdgpu version: {0:40s} {1:20s}|".format(amdgpu_version, ""))
         if rocm_version != "N/A":
             print("| ROCm version:   {0:40s} {1:28s}|".format(rocm_version, ""))
 

--- a/amdsmi_cli/amdsmi_logger.py
+++ b/amdsmi_cli/amdsmi_logger.py
@@ -1018,11 +1018,11 @@ class AMDSMILogger():
                 # Extract version using regex to find pattern like "6.8.0-60"
                 match = re.search(r'(\d+\.\d+\.\d+-\d+)', driver_version['driver_version'])
                 if match:
-                    amdgpu_version = match.group(1).ljust(8)
+                    amdgpu_version = match.group(1)[:80]
                 else:
-                    amdgpu_version = "N/A".ljust(8)
+                    amdgpu_version = "N/A"
             else:
-                amdgpu_version = str(driver_version['driver_version'])[:8].ljust(8)
+                amdgpu_version = str(driver_version['driver_version'])[:80]
         fw_pldm_version = str(output['version_info']['fw pldm version'])
         vbios_version = str(output['version_info']['vbios version'])
 

--- a/amdsmi_cli/amdsmi_logger.py
+++ b/amdsmi_cli/amdsmi_logger.py
@@ -1003,8 +1003,8 @@ class AMDSMILogger():
 
         # print the version information first
         amd_smi_version = str(output['version_info']['amd-smi'])
-        if len(amd_smi_version) > 20:
-            amd_smi_version = amd_smi_version[:17] + "..."
+        if len(amd_smi_version) > 60:
+            amd_smi_version = amd_smi_version[:57] + "..."
         rocm_version = "N/A"
         if output['version_info']['rocm version'][0]:
             rocm_version = str(output['version_info']['rocm version'][1]).ljust(8)

--- a/amdsmi_cli/amdsmi_logger.py
+++ b/amdsmi_cli/amdsmi_logger.py
@@ -1028,7 +1028,11 @@ class AMDSMILogger():
 
         # print GPU info
         print(default_line_1)
-        print("| AMD-SMI {0:20s} amdgpu version: {1:8s} ROCm version: {2:8s} |".format(amd_smi_version.ljust(20), amdgpu_version, rocm_version))
+        # Split the version line into 3 lines, each wrapping to the same width
+        print("| AMD-SMI {0:40s} {1:28s}|".format(amd_smi_version.ljust(40), ""))
+        print("| amdgpu version: {0:40s} {1:20s}|".format(amdgpu_version.ljust(40), ""))
+        if rocm_version != "N/A":
+            print("| ROCm version:   {0:40s} {1:28s}|".format(rocm_version, ""))
 
         # adjust format depending on whether vbios or fw pldm version is present
         if vbios_version != "N/A" and fw_pldm_version != "N/A":

--- a/src/amd_smi/amd_smi.cc
+++ b/src/amd_smi/amd_smi.cc
@@ -4425,6 +4425,9 @@ amdsmi_status_t amdsmi_get_gpu_driver_info(amdsmi_processor_handle processor_han
     // Get the driver version
     status = smi_amdgpu_get_driver_version(gpu_device,
                 &length, info->driver_version);
+    if (status != AMDSMI_STATUS_SUCCESS) {
+        return status;
+    }
 
     SMIGPUDEVICE_MUTEX(gpu_device->get_mutex())
     std::string render_name = gpu_device->get_gpu_path();

--- a/src/amd_smi/amd_smi_utils.cc
+++ b/src/amd_smi/amd_smi_utils.cc
@@ -615,12 +615,9 @@ amdsmi_status_t smi_amdgpu_get_driver_version(amd::smi::AMDSmiGPUDevice* device,
     std::strncpy(version, empty.c_str(), len-1);
     openFileAndModifyBuffer("/sys/module/amdgpu/version",
                                       version, static_cast<size_t>(len));
-    if (version[0] == '\0') {
-        openFileAndModifyBuffer("/proc/version", version, static_cast<size_t>(len));
-        if (version[0] == '\0') {
-            return AMDSMI_STATUS_IO;
-        }
-    }
+    if (version[0] == '\0')
+        return AMDSMI_STATUS_DIRECTORY_NOT_FOUND;
+
     return status;
 }
 


### PR DESCRIPTION
# Motivation
The default view is really cramped trying to put a lot of version information into one line, to the point that some strings are cropped.

# Technical Details
Instead of cropping the strings just put each into it's own line.
For running without a ROCm release installed hide the ROCm version line.

# Test Plan
Run the tool and look at output.

# Test Result
Sample output:

```
+------------------------------------------------------------------------------+
| AMD-SMI 26.1.0+2a668c34                                                      |
| amdgpu version: Linuxver                                                     |
| VBIOS version: 023.010.001.022.000001                                        |
| Platform: Linux Baremetal                                                    |
|-------------------------------------+----------------------------------------|
| BDF                        GPU-Name | Mem-Uti   Temp   UEC       Power-Usage |
| GPU  HIP-ID  OAM-ID  Partition-Mode | GFX-Uti    Fan               Mem-Usage |
|=====================================+========================================|
| 0000:c1:00.0 ...adeon 890M Graphics | N/A      59 °C   0                17 W |
|   0       0     N/A             N/A | 25 %       N/A              479/512 MB |
+-------------------------------------+----------------------------------------+
+------------------------------------------------------------------------------+
| Processes:                                                                   |
|  GPU        PID  Process Name          GTT_MEM  VRAM_MEM  MEM_USAGE     CU % |
|==============================================================================|
|  No running processes found                                                  |
+------------------------------------------------------------------------------+
```