### PR TITLE
[SWDEV-555654] Enable Driver reload on SRIOV

### DIFF
--- a/amdsmi_cli/amdsmi_parser.py
+++ b/amdsmi_cli/amdsmi_parser.py
@@ -1358,10 +1358,10 @@ class AMDSMIParser(argparse.ArgumentParser):
             reset_exclusive_group.add_argument('-x', '--xgmierr', action='store_true', required=False, help=reset_xgmierr_help)
             reset_exclusive_group.add_argument('-d', '--perf-determinism', action='store_true', required=False, help=reset_perf_det_help)
             reset_exclusive_group.add_argument('-o', '--power-cap', action='store_true', required=False, help=reset_power_cap_help)
-            reset_exclusive_group.add_argument('-r', '--reload-driver', action='store_true', required=False, help=reset_gpu_driver_help)
 
         # Add Baremetal and Virtual OS reset arguments
         reset_exclusive_group.add_argument('-l', '--clean-local-data', action='store_true', required=False, help=reset_gpu_clean_local_data_help)
+        reset_exclusive_group.add_argument('-r', '--reload-driver', action='store_true', required=False, help=reset_gpu_driver_help)
 
         # Reset accepts default devices of all
         self._add_device_arguments(reset_parser, required=False)


### PR DESCRIPTION
Enabled reload argument. Reload is supported
on SRIOV systems.

Fixes:
sudo amd-smi reset -g all
AttributeError: 'Namespace' object has no attribute 'reload_driver'

Change-Id: Ib75ba043e29ae6e668c18451b93e766a7528739f
Signed-off-by: Charis Poag <Charis.Poag@amd.com>
