### PR TITLE
Added --decode argument to amd-smi so we can parse cper files directly

### DIFF
--- a/amdsmi_cli/amdsmi_commands.py
+++ b/amdsmi_cli/amdsmi_commands.py
@@ -7119,7 +7119,7 @@ class AMDSMICommands():
                         output_file.write(legend_output + '\n')
 
 
-    def ras(self, args, multiple_devices=False, gpu=None, cper=None, afid=None,
+    def ras(self, args, multiple_devices=False, gpu=None, cper=None, afid=None, decode=None,
             severity=None, folder=None, file_limit=None, cper_file=None, follow=None):
         """
         Retrieve and process CPER (RAS) entries for a target GPU.
@@ -7139,6 +7139,8 @@ class AMDSMICommands():
             args.cper = cper
         if afid:
             args.afid = afid
+        if decode:
+            args.decode = decode
         if severity:
             args.severity = severity
         if folder:
@@ -7155,6 +7157,18 @@ class AMDSMICommands():
         if args.afid:
             if args.cper_file:
                 afids = self.helpers.pvtDumpAfids(args.cper_file)
+                print(' '.join(map(str, afids)))
+                return
+            else:
+                command = " ".join(sys.argv[1:])
+                message = f"Command '{command}' requires '--cper-file'. Run '--help' for more info."
+                raise AmdSmiInvalidCommandException(command,
+                                                    self.logger.format,
+                                                    message)
+
+        if args.decode:
+            if args.cper_file:
+                afids = self.helpers.pvtDumpCper(args.cper_file)
                 print(' '.join(map(str, afids)))
                 return
             else:

--- a/amdsmi_cli/amdsmi_commands.py
+++ b/amdsmi_cli/amdsmi_commands.py
@@ -7151,24 +7151,16 @@ class AMDSMICommands():
             args.cper_file = cper_file
         if follow:
             args.follow = follow
+        if args.decode and args.cper_file:
+            args.cursor = [0]
+            self.helpers.ras_cper(args, None, self.logger, 0)
+            return
         if args.gpu == None:
             args.gpu = self.device_handles
 
         if args.afid:
             if args.cper_file:
                 afids = self.helpers.pvtDumpAfids(args.cper_file)
-                print(' '.join(map(str, afids)))
-                return
-            else:
-                command = " ".join(sys.argv[1:])
-                message = f"Command '{command}' requires '--cper-file'. Run '--help' for more info."
-                raise AmdSmiInvalidCommandException(command,
-                                                    self.logger.format,
-                                                    message)
-
-        if args.decode:
-            if args.cper_file:
-                afids = self.helpers.pvtDumpCper(args.cper_file)
                 print(' '.join(map(str, afids)))
                 return
             else:

--- a/amdsmi_cli/amdsmi_commands.py
+++ b/amdsmi_cli/amdsmi_commands.py
@@ -7151,16 +7151,16 @@ class AMDSMICommands():
             args.cper_file = cper_file
         if follow:
             args.follow = follow
-        if args.decode and args.cper_file:
-            args.cursor = [0]
-            self.helpers.ras_cper(args, None, self.logger, 0)
-            return
         if args.gpu == None:
             args.gpu = self.device_handles
 
         if args.afid:
             if args.cper_file:
-                afids = self.helpers.pvtDumpAfids(args.cper_file)
+                if args.decode:
+                    args.cursor = [0]
+                    self.helpers.ras_cper(args, None, self.logger, 0)
+                    return
+                afids = self.helpers.cper_dump_afids(args.cper_file)
                 print(' '.join(map(str, afids)))
                 return
             else:

--- a/amdsmi_cli/amdsmi_helpers.py
+++ b/amdsmi_cli/amdsmi_helpers.py
@@ -1413,7 +1413,9 @@ class AMDSMIHelpers():
         for entry_index, entry in enumerate(entries.values()):
             # Assume 'entry' is a dictionary with keys: "error_severity" and "notify_type".
             timestamp = entry.get("timestamp", "unknown")
-            gpu_id = self.get_gpu_id_from_device_handle(device_handle)
+            gpu_id = '-'
+            if not isinstance(device_handle, Path):
+                gpu_id = self.get_gpu_id_from_device_handle(device_handle)
             prefix = self._severity_as_string(entry.get("error_severity", "Unknown"),
                                               entry.get("notify_type", "Unknown"),
                                               False)
@@ -1495,7 +1497,9 @@ class AMDSMIHelpers():
             
                 # Collect data for printing
                 timestamp = entry.get("timestamp", "unknown")
-                gpu_id = self.get_gpu_id_from_device_handle(device_handle)
+                gpu_id = '-'
+                if not isinstance(device_handle, Path):
+                    gpu_id = self.get_gpu_id_from_device_handle(device_handle)
                 severity = self._severity_as_string(error_severity, notify_type, False)
                 output_rows[cper_path] = [timestamp, gpu_id, severity, cper_name]
                 self.increment_cper_count()
@@ -1594,38 +1598,6 @@ class AMDSMIHelpers():
 
         return "\n".join(lines)
 
-    def pvtDumpCper(self, cper_file):
-        # 1) Fetch the CPER “file” and ensure we have raw bytes
-        raw_data = cper_file
-        if hasattr(raw_data, "read"):
-            # fetch_cper_file returned a file‐object
-            raw = raw_data.read()
-        elif isinstance(raw_data, Path):
-            # Path: read the bytes directly
-            raw = raw_data.read_bytes()
-        elif isinstance(raw_data, str):
-            # fetch_cper_file returned a filename
-            with open(raw_data, "rb") as f:
-                    raw = f.read()
-        else:
-            # assume it's already bytes
-            raw = raw_data
-        self.binary_to_hexdump_string(raw)
-        try:
-            afids, num_afids = amdsmi_interface.amdsmi_get_afids_from_cper(raw)
-            return afids
-        except amdsmi_exception.AmdSmiLibraryException as e:
-            if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_INVAL:
-                raise ValueError("Invalid CPER file inputs") from e
-            elif e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_UNEXPECTED_SIZE:
-                raise ValueError("Invalid CPER file data size") from e
-            elif e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_UNEXPECTED_DATA:
-                raise ValueError("Unexpected data in CPER file") from e
-            elif e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED:
-                raise NotImplementedError("AFID decoding not supported") from e
-            else:
-                raise ValueError("Unexpected Error getting afids from CPER file") from e
-
     def pvtDumpAfids(self, cper_file):
         # 1) Fetch the CPER “file” and ensure we have raw bytes
         raw_data = cper_file
@@ -1717,14 +1689,16 @@ class AMDSMIHelpers():
 
         buffer_size = 1048576
 
-        gpu_id = self.get_gpu_id_from_device_handle(device_handle)
-        if args.follow and not getattr(self, "_cper_follow_prompted", False):
-            print("Press CTRL + C to stop.")
-            self._cper_follow_prompted = True
-
-        primary_partition = self.is_primary_partition(device_handle, gpu_id)
-        if not primary_partition:
-            return
+        if args.decode and args.cper_file:
+            device_handle = args.cper_file
+        else:
+            gpu_id = self.get_gpu_id_from_device_handle(device_handle)
+            if args.follow and not getattr(self, "_cper_follow_prompted", False):
+                print("Press CTRL + C to stop.")
+                self._cper_follow_prompted = True
+            primary_partition = self.is_primary_partition(device_handle, gpu_id)
+            if not primary_partition:
+                return
 
         if args.folder and not getattr(self, "_cper_folder_prompted", False):
             self._cper_folder_prompted = True
@@ -1733,6 +1707,7 @@ class AMDSMIHelpers():
         self.stop = False
 
         num_entries = 0
+        entries = {}
         while True:
             try:
                 entries, new_cursor, cper_data, status_code = amdsmi_interface.amdsmi_get_gpu_cper_entries(

--- a/amdsmi_cli/amdsmi_helpers.py
+++ b/amdsmi_cli/amdsmi_helpers.py
@@ -34,6 +34,7 @@ import errno
 import pwd
 import stat
 from typing import Tuple, Optional, Union
+import tempfile
 
 from enum import Enum
 from pathlib import Path
@@ -1749,15 +1750,14 @@ class AMDSMIHelpers():
             if len(entries) == 0:
                 break
             if args.decode and args.cper_file:
-                if args.folder:
-                    self.dump_cper_entries(args.folder, entries, cper_data, device_handle, args.file_limit)
-                afids = self.cper_dump_afids(args.cper_file)
-                afids_str = ' '.join(map(str, afids))
                 if args.json:
                     self.dump_cper_entries_as_json(entries, cper_data, device_handle)
-                else:
-                    print(' '.join(map(str, afids)))
-            if args.folder:
+                elif args.folder:
+                    self.dump_cper_entries(args.folder, entries, cper_data, device_handle, args.file_limit)
+                else: 
+                    with tempfile.TemporaryDirectory() as tmpdirname: #dump_cper_entries needs a folder in order to print info out
+                        self.dump_cper_entries(tmpdirname, entries, cper_data, device_handle, args.file_limit)
+            elif args.folder:
                 self.dump_cper_entries(args.folder, entries, cper_data, device_handle, args.file_limit)
             else:
                 self.display_cper_files_generated(entries, device_handle, args.folder)

--- a/amdsmi_cli/amdsmi_helpers.py
+++ b/amdsmi_cli/amdsmi_helpers.py
@@ -1748,12 +1748,13 @@ class AMDSMIHelpers():
             args.cursor[gpu_idx] = new_cursor
             if len(entries) == 0:
                 break
-            if args.decode and args.cper_file and not args.folder:
-                afids = self.pvtDumpAfids(args.cper_file)
-                afids_str = ' '.join(map(str, afids))
-                self.dump_cper_entries_as_json(entries, cper_data, device_handle)
-            if args.decode and args.cper_file and args.folder:
-                self.dump_cper_entries(args.folder, entries, cper_data, device_handle, args.file_limit)
+            if args.decode and args.cper_file:
+                if args.folder:
+                    self.dump_cper_entries(args.folder, entries, cper_data, device_handle, args.file_limit)
+                else:
+                    afids = self.pvtDumpAfids(args.cper_file)
+                    afids_str = ' '.join(map(str, afids))
+                    self.dump_cper_entries_as_json(entries, cper_data, device_handle)
             if args.folder:
                 self.dump_cper_entries(args.folder, entries, cper_data, device_handle, args.file_limit)
             else:

--- a/amdsmi_cli/amdsmi_helpers.py
+++ b/amdsmi_cli/amdsmi_helpers.py
@@ -1751,7 +1751,6 @@ class AMDSMIHelpers():
             if args.decode and args.cper_file and not args.folder:
                 afids = self.pvtDumpAfids(args.cper_file)
                 afids_str = ' '.join(map(str, afids))
-                print("AFIDS: " + afids_str)
                 self.dump_cper_entries_as_json(entries, cper_data, device_handle)
             if args.decode and args.cper_file and args.folder:
                 self.dump_cper_entries(args.folder, entries, cper_data, device_handle, args.file_limit)

--- a/amdsmi_cli/amdsmi_helpers.py
+++ b/amdsmi_cli/amdsmi_helpers.py
@@ -1540,16 +1540,14 @@ class AMDSMIHelpers():
             except Exception as e:
                 logging.debug(f"Failed to dump entries as JSON: {e}")
     
-    def dump_cper_entries_as_json(self, entries, cper_data, device_handle):
+    def dump_cper_entries_as_json(self, entries, _cper_data, _device_handle):
         """
         Return the CPER entries as a formatted JSON string and print it.
         Parameters largely mirror dump_cper_entries so that callers can reuse the same argument list.
-        Unused arguments (cper_data, device_handle) are retained for API symmetry.
+        Unused arguments (_cper_data, _device_handle) are retained for API symmetry.
         Returns:
         str: The JSON representation of the CPER entries, or an empty string on failure.
         """
-        # Explicitly touch unused parameters to avoid lint warnings in static analyzers.
-        _ = cper_data, device_handle
         try:
             entries_json = json.dumps(
                 entries,

--- a/amdsmi_cli/amdsmi_helpers.py
+++ b/amdsmi_cli/amdsmi_helpers.py
@@ -1594,6 +1594,38 @@ class AMDSMIHelpers():
 
         return "\n".join(lines)
 
+    def pvtDumpCper(self, cper_file):
+        # 1) Fetch the CPER “file” and ensure we have raw bytes
+        raw_data = cper_file
+        if hasattr(raw_data, "read"):
+            # fetch_cper_file returned a file‐object
+            raw = raw_data.read()
+        elif isinstance(raw_data, Path):
+            # Path: read the bytes directly
+            raw = raw_data.read_bytes()
+        elif isinstance(raw_data, str):
+            # fetch_cper_file returned a filename
+            with open(raw_data, "rb") as f:
+                    raw = f.read()
+        else:
+            # assume it's already bytes
+            raw = raw_data
+        self.binary_to_hexdump_string(raw)
+        try:
+            afids, num_afids = amdsmi_interface.amdsmi_get_afids_from_cper(raw)
+            return afids
+        except amdsmi_exception.AmdSmiLibraryException as e:
+            if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_INVAL:
+                raise ValueError("Invalid CPER file inputs") from e
+            elif e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_UNEXPECTED_SIZE:
+                raise ValueError("Invalid CPER file data size") from e
+            elif e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_UNEXPECTED_DATA:
+                raise ValueError("Unexpected data in CPER file") from e
+            elif e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED:
+                raise NotImplementedError("AFID decoding not supported") from e
+            else:
+                raise ValueError("Unexpected Error getting afids from CPER file") from e
+
     def pvtDumpAfids(self, cper_file):
         # 1) Fetch the CPER “file” and ensure we have raw bytes
         raw_data = cper_file

--- a/amdsmi_cli/amdsmi_helpers.py
+++ b/amdsmi_cli/amdsmi_helpers.py
@@ -1425,7 +1425,7 @@ class AMDSMIHelpers():
                                                 entry.get("notify_type", "Unknown"),
                                                 True)
                 cper_data_file = f"{prefix}_{self.get_cper_count() + 1}.cper"
-                afids = self.pvtDumpAfids(cper_data_file)
+                afids = self.cper_dump_afids(cper_data_file)
                 afids_str = ' '.join(map(str, afids))
                 output += f" {cper_data_file:<17} {afids_str}"
 
@@ -1522,7 +1522,7 @@ class AMDSMIHelpers():
             for cper_path, row in output_rows.items():
                 timestamp, gpu_id, severity, fname = row
                 try:
-                    afids = self.pvtDumpAfids(cper_path)
+                    afids = self.cper_dump_afids(cper_path)
                     afids_str = ' '.join(map(str, afids))
                 except Exception as e:
                     afids_str = "Error fetching AFIDs"
@@ -1618,7 +1618,7 @@ class AMDSMIHelpers():
 
         return "\n".join(lines)
 
-    def pvtDumpAfids(self, cper_file):
+    def cper_dump_afids(self, cper_file):
         # 1) Fetch the CPER “file” and ensure we have raw bytes
         raw_data = cper_file
         if hasattr(raw_data, "read"):
@@ -1752,7 +1752,7 @@ class AMDSMIHelpers():
                 if args.folder:
                     self.dump_cper_entries(args.folder, entries, cper_data, device_handle, args.file_limit)
                 else:
-                    afids = self.pvtDumpAfids(args.cper_file)
+                    afids = self.cper_dump_afids(args.cper_file)
                     afids_str = ' '.join(map(str, afids))
                     self.dump_cper_entries_as_json(entries, cper_data, device_handle)
             if args.folder:

--- a/amdsmi_cli/amdsmi_helpers.py
+++ b/amdsmi_cli/amdsmi_helpers.py
@@ -1751,10 +1751,12 @@ class AMDSMIHelpers():
             if args.decode and args.cper_file:
                 if args.folder:
                     self.dump_cper_entries(args.folder, entries, cper_data, device_handle, args.file_limit)
-                else:
-                    afids = self.cper_dump_afids(args.cper_file)
-                    afids_str = ' '.join(map(str, afids))
+                afids = self.cper_dump_afids(args.cper_file)
+                afids_str = ' '.join(map(str, afids))
+                if args.json:
                     self.dump_cper_entries_as_json(entries, cper_data, device_handle)
+                else:
+                    print(' '.join(map(str, afids)))
             if args.folder:
                 self.dump_cper_entries(args.folder, entries, cper_data, device_handle, args.file_limit)
             else:

--- a/amdsmi_cli/amdsmi_helpers.py
+++ b/amdsmi_cli/amdsmi_helpers.py
@@ -1539,6 +1539,28 @@ class AMDSMIHelpers():
                 ))
             except Exception as e:
                 logging.debug(f"Failed to dump entries as JSON: {e}")
+    
+    def dump_cper_entries_as_json(self, entries, cper_data, device_handle):
+        """
+        Return the CPER entries as a formatted JSON string and print it.
+        Parameters largely mirror dump_cper_entries so that callers can reuse the same argument list.
+        Unused arguments (cper_data, device_handle) are retained for API symmetry.
+        Returns:
+        str: The JSON representation of the CPER entries, or an empty string on failure.
+        """
+        # Explicitly touch unused parameters to avoid lint warnings in static analyzers.
+        _ = cper_data, device_handle
+        try:
+            entries_json = json.dumps(
+                entries,
+                indent=2,
+                default=lambda o: o.decode("utf-8") if isinstance(o, bytes) else o,
+            )
+            print(entries_json)
+            return entries_json
+        except Exception as e:
+            logging.debug(f"Failed to serialize CPER entries as JSON: {e}")
+            return ""
 
     def write_binary(self, data, size, filepath):
         """
@@ -1728,6 +1750,13 @@ class AMDSMIHelpers():
             args.cursor[gpu_idx] = new_cursor
             if len(entries) == 0:
                 break
+            if args.decode and args.cper_file and not args.folder:
+                afids = self.pvtDumpAfids(args.cper_file)
+                afids_str = ' '.join(map(str, afids))
+                print("AFIDS: " + afids_str)
+                self.dump_cper_entries_as_json(entries, cper_data, device_handle)
+            if args.decode and args.cper_file and args.folder:
+                self.dump_cper_entries(args.folder, entries, cper_data, device_handle, args.file_limit)
             if args.folder:
                 self.dump_cper_entries(args.folder, entries, cper_data, device_handle, args.file_limit)
             else:

--- a/amdsmi_cli/amdsmi_parser.py
+++ b/amdsmi_cli/amdsmi_parser.py
@@ -1524,10 +1524,11 @@ class AMDSMIParser(argparse.ArgumentParser):
         ras_parser.formatter_class = lambda prog: AMDSMISubparserHelpFormatter(prog)
         ras_parser.set_defaults(func=func)
 
-        # Create mutually exclusive command ras group (--cper or --afid)
+        # Create mutually exclusive command ras group (--cper or --afid or --decode)
         ras_exclusive_group = ras_parser.add_mutually_exclusive_group(required=True)
         ras_exclusive_group.add_argument("--cper", action="store_true", help=cper_help)
         ras_exclusive_group.add_argument("--afid", action="store_true", help=afid_help)
+        ras_exclusive_group.add_argument("--decode", action="store_true", help=afid_help)
 
         # CPER Arguments remove defaults
         cper_group = ras_parser.add_argument_group("CPER Arguments")

--- a/amdsmi_cli/amdsmi_parser.py
+++ b/amdsmi_cli/amdsmi_parser.py
@@ -1511,6 +1511,7 @@ class AMDSMIParser(argparse.ArgumentParser):
         # Help text for RAS arguments
         cper_help = "Trigger current CPER data retrieval"
         afid_help = "Generate an AFID (AMD Field ID) given a CPER record file"
+        decode_help = "Decode out‑of‑band CPER files captured by or collected from other systems"
         severity_choices = ["nonfatal-uncorrected", "fatal", "nonfatal-corrected", "all"]
         severity_choices_str = ", ".join(severity_choices)
         severity_help = f"Set the SEVERITY filters from the following:\n    {severity_choices_str}"
@@ -1528,7 +1529,7 @@ class AMDSMIParser(argparse.ArgumentParser):
         ras_exclusive_group = ras_parser.add_mutually_exclusive_group(required=True)
         ras_exclusive_group.add_argument("--cper", action="store_true", help=cper_help)
         ras_exclusive_group.add_argument("--afid", action="store_true", help=afid_help)
-        ras_exclusive_group.add_argument("--decode", action="store_true", help=afid_help)
+        ras_exclusive_group.add_argument("--decode", action="store_true", help=decode_help)
 
         # CPER Arguments remove defaults
         cper_group = ras_parser.add_argument_group("CPER Arguments")

--- a/amdsmi_cli/amdsmi_parser.py
+++ b/amdsmi_cli/amdsmi_parser.py
@@ -1511,7 +1511,7 @@ class AMDSMIParser(argparse.ArgumentParser):
         # Help text for RAS arguments
         cper_help = "Trigger current CPER data retrieval"
         afid_help = "Generate an AFID (AMD Field ID) given a CPER record file"
-        decode_help = "Decode out‑of‑band CPER files captured by or collected from other systems"
+        decode_help = "Decode out-of-band CPER files captured by or collected from other systems"
         severity_choices = ["nonfatal-uncorrected", "fatal", "nonfatal-corrected", "all"]
         severity_choices_str = ", ".join(severity_choices)
         severity_help = f"Set the SEVERITY filters from the following:\n    {severity_choices_str}"

--- a/amdsmi_cli/amdsmi_parser.py
+++ b/amdsmi_cli/amdsmi_parser.py
@@ -1525,11 +1525,10 @@ class AMDSMIParser(argparse.ArgumentParser):
         ras_parser.formatter_class = lambda prog: AMDSMISubparserHelpFormatter(prog)
         ras_parser.set_defaults(func=func)
 
-        # Create mutually exclusive command ras group (--cper or --afid or --decode)
+        # Create mutually exclusive command ras group (--cper or --afid)
         ras_exclusive_group = ras_parser.add_mutually_exclusive_group(required=True)
         ras_exclusive_group.add_argument("--cper", action="store_true", help=cper_help)
         ras_exclusive_group.add_argument("--afid", action="store_true", help=afid_help)
-        ras_exclusive_group.add_argument("--decode", action="store_true", help=decode_help)
 
         # CPER Arguments remove defaults
         cper_group = ras_parser.add_argument_group("CPER Arguments")
@@ -1541,6 +1540,7 @@ class AMDSMIParser(argparse.ArgumentParser):
         # AFID Arguments
         afid_group = ras_parser.add_argument_group("AFID Arguments")
         afid_group.add_argument("--cper-file", action=self._check_cper_file_path(), metavar="CPER_FILE", help=cper_file_help)
+        cper_group.add_argument("--decode", action="store_true", help=decode_help)
 
         # Add common modifiers and device selection arguments.
         self._add_device_arguments(ras_parser, required=False)

--- a/amdsmi_cli/amdsmi_parser.py
+++ b/amdsmi_cli/amdsmi_parser.py
@@ -1540,7 +1540,7 @@ class AMDSMIParser(argparse.ArgumentParser):
         # AFID Arguments
         afid_group = ras_parser.add_argument_group("AFID Arguments")
         afid_group.add_argument("--cper-file", action=self._check_cper_file_path(), metavar="CPER_FILE", help=cper_file_help)
-        cper_group.add_argument("--decode", action="store_true", help=decode_help)
+        afid_group.add_argument("--decode", action="store_true", help=decode_help)
 
         # Add common modifiers and device selection arguments.
         self._add_device_arguments(ras_parser, required=False)

--- a/cmake.sh
+++ b/cmake.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -xe
+  set -xe
+  cmake   -DCMAKE_BUILD_TYPE=Debug   -DCMAKE_INSTALL_PREFIX=/opt/rocm-6.5.0   -DBUILD_TESTS=ON   ..
+  #-DBUILD_WRAPPER=ON   #
+  

--- a/py-interface/amdsmi_interface.py
+++ b/py-interface/amdsmi_interface.py
@@ -2686,15 +2686,20 @@ def notifyTypeToString(notify_type_b):
     return "".join(guid[::-1])
 
 def amdsmi_get_gpu_cper_entries(
-    processor_handle: Union[amdsmi_wrapper.amdsmi_processor_handle, str],
+    device_handle: amdsmi_wrapper.amdsmi_processor_handle | Path,
+    # processor_handle: Union[amdsmi_wrapper.amdsmi_processor_handle, str],
     severity_mask: int,
     buffer_size: int = 4 * 1048576,
     cursor: int = 0
 ) -> Tuple[Dict[str, Any], int, List[Dict[str, Any]], int]:
 
-    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle) and not isinstance(processor_handle, str):
+    if isinstance(device_handle, Path):
+        if not os.path.isfile(device_handle):
+            raise AmdSmiParameterException(device_handle, str)
+        device_handle = ctypes.c_char_p(str(device_handle).encode("utf-8"))
+    elif not isinstance(device_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(
-            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+            device_handle, amdsmi_wrapper.amdsmi_processor_handle
         )
 
     # Allocate a buffer for CPER data.
@@ -2710,7 +2715,7 @@ def amdsmi_get_gpu_cper_entries(
 
     # Call the underlying AMD-SMI API.
     status_code = amdsmi_wrapper.amdsmi_get_gpu_cper_entries(
-        processor_handle,
+        device_handle,
         ctypes.c_uint32(severity_mask),
         buf,
         ctypes.byref(buf_size),

--- a/py-interface/amdsmi_interface.py
+++ b/py-interface/amdsmi_interface.py
@@ -2686,13 +2686,13 @@ def notifyTypeToString(notify_type_b):
     return "".join(guid[::-1])
 
 def amdsmi_get_gpu_cper_entries(
-    processor_handle: processor_handle_t,
+    processor_handle: Union[amdsmi_wrapper.amdsmi_processor_handle, str],
     severity_mask: int,
     buffer_size: int = 4 * 1048576,
     cursor: int = 0
 ) -> Tuple[Dict[str, Any], int, List[Dict[str, Any]], int]:
 
-    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle) and not isinstance(processor_handle, str):
         raise AmdSmiParameterException(
             processor_handle, amdsmi_wrapper.amdsmi_processor_handle
         )

--- a/src/amd_smi/amd_smi.cc
+++ b/src/amd_smi/amd_smi.cc
@@ -4307,6 +4307,12 @@ amdsmi_get_gpu_cper_entries(
     uint64_t *entry_count,
     uint64_t *cursor) {
 
+    std::string path;
+    if(amd::smi::FileExists(static_cast<char const *>(processor_handle))) {
+        path = std::string(static_cast<char const *>(processor_handle));
+    }
+    else {
+
     AMDSMI_CHECK_INIT();
     if (!amd::smi::is_sudo_user()) {
         return AMDSMI_STATUS_NO_PERM;
@@ -4317,12 +4323,10 @@ amdsmi_get_gpu_cper_entries(
     if (status != AMDSMI_STATUS_SUCCESS) {
         return status;
     }
-    std::string path = std::string("/sys/kernel/debug/dri/") +
+    path = std::string("/sys/kernel/debug/dri/") +
         std::to_string(gpu_device->get_card_id()) +
         "/amdgpu_ring_cper";
-
-    printf("@@@ path: %s\n", path.c_str());
-
+    }
 
     return amdsmi_get_gpu_cper_entries_by_path(
         path.c_str(),

--- a/src/amd_smi/amd_smi.cc
+++ b/src/amd_smi/amd_smi.cc
@@ -4321,6 +4321,8 @@ amdsmi_get_gpu_cper_entries(
         std::to_string(gpu_device->get_card_id()) +
         "/amdgpu_ring_cper";
 
+    printf("@@@ path: %s\n", path.c_str());
+
 
     return amdsmi_get_gpu_cper_entries_by_path(
         path.c_str(),


### PR DESCRIPTION
==================================================================
Adjusted output to match design requirements:

<img width="1411" height="706" alt="image" src="https://github.com/user-attachments/assets/6e717e0f-25e8-4fb2-9eac-e3d3e851c69a" />
==================================================================

Sample output:

<img width="1238" height="524" alt="image" src="https://github.com/user-attachments/assets/05d35a12-8b98-425e-b432-c955fcce37d4" />
