### PR TITLE
List of afids prints garbage values when given invalid cper files

### DIFF
--- a/src/amd_smi/amd_smi_cper.cc
+++ b/src/amd_smi/amd_smi_cper.cc
@@ -489,30 +489,31 @@ std::vector<int> cper_decode(const amdsmi_cper_hdr_t *cper) {
         cper_sec_desc *section = static_cast<struct cper_sec_desc *>(sec_desc_offset);
         cper_dump_sec_desc(section);
 
+        int afid = -1;
         if (cper_is_cr(sec_guid)) {
             struct cper_sec_crashdump *crashdump = static_cast<struct cper_sec_crashdump *>(sec_offset);
             if (cper_is_bt(cper_guid)) {
                 ss << __PRETTY_FUNCTION__ << "\n:" << __LINE__ << "[AFIDS] decoding boot crash dump\n";
                 LOG_DEBUG(ss);
-                afids.emplace_back(cper_dump_cr_boot(crashdump, section));
+                afid = cper_dump_cr_boot(crashdump, section);
             }
             else {
                 ss << __PRETTY_FUNCTION__ << "\n:" << __LINE__ << "[AFIDS] decoding crash dump\n";
                 LOG_DEBUG(ss);
-                afids.emplace_back(cper_dump_cr_fatal(crashdump, section));
+                afid = cper_dump_cr_fatal(crashdump, section);
             }
         }
         else if (cper_is_nonstd(sec_guid)) {
             struct cper_sec_nonstd_err *crashdump = static_cast<struct cper_sec_nonstd_err *>(sec_offset);
             ss << __PRETTY_FUNCTION__ << "\n:" << __LINE__ << "[AFIDS] decoding non-standard error\n";
             LOG_DEBUG(ss);
-            afids.emplace_back(cper_dump_nonstd_err(crashdump, section));
+            afid = cper_dump_nonstd_err(crashdump, section);
         } 
         else if (cper_is_proc_err(sec_guid)) {
             struct cper_sec_nonstd_err *crashdump = static_cast<struct cper_sec_nonstd_err *>(sec_offset);
             ss << __PRETTY_FUNCTION__ << "\n:" << __LINE__ << "[AFIDS] decoding proc error section type\n";
             LOG_DEBUG(ss);
-            afids.emplace_back(cper_dump_nonstd_err(crashdump, section));
+            afid = cper_dump_nonstd_err(crashdump, section);
         } 
         else {
             ss << __PRETTY_FUNCTION__ << "\n:" << __LINE__ << "[AFIDS] Unknown error type!!\n";
@@ -521,6 +522,9 @@ std::vector<int> cper_decode(const amdsmi_cper_hdr_t *cper) {
             }
             ss << "\n";
             LOG_ERROR(ss);
+        }
+        if(afid != -1) {
+            afids.emplace_back(afid);
         }
     }
 


### PR DESCRIPTION
When processing corrupt CPER entries, the output for 'list of afids' is garbage like this:

```
timestamp            gpu_id  severity             file_name         list of afids
2000/01/09 14:08:24  -       FATAL                fatal-1.cper      18446744073709551615 18446744073709551615 18446744073709551615 18446744073709551615
2000/01/09 14:08:24  -       FATAL                fatal-2.cper      18446744073709551615 18446744073709551615 18446744073709551615 18446744073709551615
```

After this fix, the output is like this:

```
timestamp            gpu_id  severity             file_name         list of afids
2000/01/09 14:08:24  -       FATAL                fatal-1.cper
2000/01/09 14:08:24  -       FATAL                fatal-2.cper
```