### PR TITLE
[Docs] Add environment variable reference page

### DIFF
--- a/docs/how-to/amdsmi-cpp-lib.md
+++ b/docs/how-to/amdsmi-cpp-lib.md
@@ -14,23 +14,13 @@ serves as a valuable tool for leveraging the full potential of AMD hardware in
 your projects.
 
 ```{note}
-``hipcc`` and other compilers will not automatically link in the ``libamd_smi``
-dynamic library. To compile code that uses the AMD SMI library API, ensure the
-``libamd_smi.so`` can be located by setting the ``LD_LIBRARY_PATH`` environment
-variable to the directory containing ``librocm_smi64.so`` (usually
-``/opt/rocm/lib``) or by passing the ``-lamd_smi`` flag to the compiler.
-```
-
-```{note}
-The environment variable ``AMDSMI_GPU_METRICS_CACHE_MS`` may be set to
-control the internal GPU metrics cache duration (ms). 
-Default 1, set to 0 to disable.
-```
-
-```{note}
-The environment variable ``AMDSMI_ASIC_INFO_CACHE_MS`` may be set to
-control the internal GPU asic info cache duration (ms). 
-Default 10000 ms, set to 0 to disable.
+- ``hipcc`` and other compilers will not automatically link in the ``libamd_smi``
+  dynamic library. To compile code that uses the AMD SMI library API, ensure the
+  ``libamd_smi.so`` can be located by setting the ``LD_LIBRARY_PATH`` environment
+  variable to the directory containing ``librocm_smi64.so`` (usually
+  ``/opt/rocm/lib``) or by passing the ``-lamd_smi`` flag to the compiler.
+- Some behaviors can be controlled via environment variables. For more information,
+  see [environment variable](../reference/amdsmi-env-var.md) page.
 ```
 
 ```{seealso}

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ AMD SMI is the successor to <https://github.com/ROCm/rocm_smi_lib>.
   * [Data fields](../doxygen/docBin/html/functions_data_fields)
 * [Python API](./reference/amdsmi-py-api.md)
 * [Go API](./reference/amdsmi-go-api.md)
+* [Environment variables](./reference/amdsmi-env-var.md)
 :::
 
 :::{grid-item-card} Conceptual

--- a/docs/reference/amdsmi-env-var.md
+++ b/docs/reference/amdsmi-env-var.md
@@ -1,0 +1,26 @@
+---
+myst:
+  html_meta:
+    "description lang=en": "Explore the AMD SMI environment variable references."
+    "keywords": "api, smi, ROCm, environment variables, environment, reference, settings, AMD SMI"
+---
+
+# AMD SMI environment variable reference
+
+This section describes the environment variables used to control the behavior of AMD SMI.
+
+```{list-table}
+:header-rows: 1
+:widths: 70 30
+
+* - **Environment variable**
+  - **Value**
+* - `AMDSMI_ASIC_INFO_CACHE_MS` \
+    Configures the cache duration for ASIC information retrieved by `amdsmi_get_gpu_asic_info` API calls. The cache stores ASIC info for each GPU device to improve performance by avoiding redundant hardware queries.
+  - Duration in milliseconds \
+    Default: `10000`
+* - `AMDSMI_GPU_METRICS_CACHE_MS` \
+    Configures the cache duration for GPU metrics retrieved by GPU metrics API calls. The cache stores metrics for each GPU device to improve performance by avoiding redundant hardware queries.
+  - Duration in milliseconds \
+    Default: `1`
+```

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -48,6 +48,8 @@ subtrees:
     title: Python API
   - file: reference/amdsmi-go-api.md
     title: Go API
+  - file: reference/amdsmi-env-var.md
+    title: Environment variables
   - file: reference/changelog.md
     title: Changelog
 


### PR DESCRIPTION
## Motivation

We've introduced a standard for environment variables to adhere to a format and to be placed in a page of its own - so it can be linked here https://rocm.docs.amd.com/en/latest/reference/env-variables.html#environment-variables-in-rocm-libraries

## Technical Details

Only docs changes - move environment variables to amdsmi-env-var.md

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
