### PR TITLE
Fix compilation with libdrm-2.4.130

### DIFF
--- a/include/amd_smi/impl/amdgpu_drm.h
+++ b/include/amd_smi/impl/amdgpu_drm.h
@@ -1625,15 +1625,6 @@ struct drm_amdgpu_info_uq_metadata {
 #define AMDGPU_FAMILY_GC_11_5_0			150 /* GC 11.5.0 */
 #define AMDGPU_FAMILY_GC_12_0_0			152 /* GC 12.0.0 */
 
-/* FIXME wrong namespace! */
-struct drm_color_ctm_3x4 {
-	/*
-	 * Conversion matrix with 3x4 dimensions in S31.32 sign-magnitude
-	 * (not two's complement!) format.
-	 */
-	__u64 matrix[12];
-};
-
 #if defined(__cplusplus)
 }
 #endif


### PR DESCRIPTION
## Motivation

Originally reported in https://bugs.gentoo.org/967246. amdsmi fails to compile with the latest libdrm-2.4.130 with error: redefinition of 'struct drm_color_ctm_3x4'.

drm_color_ctm_3x4 structure is now defined in https://github.com/torvalds/linux/commit/e5719e7f19009d4fbedf685fc22eec9cd8de154f#diff-4c51fb416ec7cc69566cd7b795ee57eb070aa1006ad65d6962081f039ffb2718

## Technical Details

As this structure is unused and not a part of amdsmi public interface, it is safe to remove it.

## Test Plan

N/A, it's a dead code removal, which fixes compilation error.

## Test Result

It compiles with libdrm-2.4.130

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
