### PR TITLE
Fix mistake that disabled FORTIFY source security flag

### DIFF
--- a/cmake_modules/help_package.cmake
+++ b/cmake_modules/help_package.cmake
@@ -54,7 +54,7 @@ function(generic_package)
         set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${ASAN_LINKER_FLAGS}" PARENT_SCOPE)
     else()
         ## Security breach mitigation flags
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFORTIFY_SOURCE=2 -fstack-protector-all -Wcast-align" PARENT_SCOPE)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_FORTIFY_SOURCE=2 -fstack-protector-all -Wcast-align" PARENT_SCOPE)
         ## More security breach mitigation flags
         set(HARDENING_LDFLAGS "${HARDENING_LDFLAGS} -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${HARDENING_LDFLAGS}" PARENT_SCOPE)


### PR DESCRIPTION
## Motivation

FORTIFY_SOURCE,  a security hardening mechanism, is currently disabled.


## Technical Details

Due to a mistake in the makefile, it is currently disabled. PR fixes the mistake and properly restores
FORTIFY_SOURCE security mechanism.



## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
