### PR TITLE
Fix compilation on openSUSE Tumbleweed

### DIFF
--- a/include/amd_smi/impl/amdgpu_drm.h
+++ b/include/amd_smi/impl/amdgpu_drm.h
@@ -1625,15 +1625,6 @@ struct drm_amdgpu_info_uq_metadata {
 #define AMDGPU_FAMILY_GC_11_5_0			150 /* GC 11.5.0 */
 #define AMDGPU_FAMILY_GC_12_0_0			152 /* GC 12.0.0 */
 
-/* FIXME wrong namespace! */
-struct drm_color_ctm_3x4 {
-	/*
-	 * Conversion matrix with 3x4 dimensions in S31.32 sign-magnitude
-	 * (not two's complement!) format.
-	 */
-	__u64 matrix[12];
-};
-
 #if defined(__cplusplus)
 }
 #endif


### PR DESCRIPTION
## Motivation

Without this patch, compilation of `amd_smi_gpu_device.cc` failed with
```
 In file included from /home/abuild/rpmbuild/BUILD/amdsmi-6.4.2-build/amdsmi-rocm-6.4.2/include/amd_smi/impl/amd_smi_drm.h:35,
                  from /home/abuild/rpmbuild/BUILD/amdsmi-6.4.2-build/amdsmi-rocm-6.4.2/include/amd_smi/impl/amd_smi_gpu_device.h:28,
                  from /home/abuild/rpmbuild/BUILD/amdsmi-6.4.2-build/amdsmi-rocm-6.4.2/src/amd_smi/amd_smi_gpu_device.cc:30:
 /home/abuild/rpmbuild/BUILD/amdsmi-6.4.2-build/amdsmi-rocm-6.4.2/include/amd_smi/impl/amdgpu_drm.h:1309:8: error: redefinition of ‘struct drm_color_ctm_3x4’
  1309 | struct drm_color_ctm_3x4 {
       |        ^~~~~~~~~~~~~~~~~
 In file included from /usr/include/libdrm/drm.h:1082,
                  from /home/abuild/rpmbuild/BUILD/amdsmi-6.4.2-build/amdsmi-rocm-6.4.2/include/amd_smi/impl/amdgpu_drm.h:39:
 /usr/include/libdrm/drm_mode.h:850:8: note: previous definition of ‘struct drm_color_ctm_3x4’
   850 | struct drm_color_ctm_3x4 {
       |        ^~~~~~~~~~~~~~~~~
```


<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
I tested compilation for older openSUSE Leap 15.6 and new openSUSE Tumbleweed.

## Test Result

<!-- Briefly summarize test outcomes. -->
compilation still works for tested builds.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
