### PR TITLE
fix: (docs) amdsmi_power_info_t->power_limit is really micro watts

### DIFF
--- a/include/amd_smi/amdsmi.h
+++ b/include/amd_smi/amdsmi.h
@@ -1117,7 +1117,7 @@ typedef struct {
     uint64_t gfx_voltage;           //!< GFX voltage measurement in mV
     uint64_t soc_voltage;           //!< SOC voltage measurement in mV
     uint64_t mem_voltage;           //!< MEM voltage measurement in mV
-    uint32_t power_limit;           //!< The power limit in W
+    uint32_t power_limit;           //!< The power limit in mu-W
     uint64_t reserved[18];
 } amdsmi_power_info_t;
 


### PR DESCRIPTION
This value is actually microwatts, so this updates the documentation.

You can see that even in `amd-smi` CLI tool, it is converted from `SI_Unit.MICRO` [here](https://github.com/ROCm/amdsmi/blob/amd-mainline/amdsmi_cli/amdsmi_commands.py#L640)

This value is populated into the `amdsmi_power_info_t` struct by reading `powerX_cap` out of the associated `hwmon` in `sysfs`. That can be seen [here](https://github.com/ROCm/amdsmi/blob/amd-mainline/src/amd_smi/amd_smi_utils.cc#L246-L274)

Further, on an MI325X system, the card is certainly _not_ capable of running at 1000000000 Watts:

```
root@linux:~# lspci | grep 06:00
06:00.0 Processing accelerators: Advanced Micro Devices, Inc. [AMD/ATI] Aqua Vanjaram [Instinct MI325X]
root@linux:~# cat /sys/bus/pci/devices/0000\:06\:00.0/hwmon/hwmon9/power1_cap
1000000000
```

From my testing, the other values in this struct, i.e `current_socket_power` do appear to return values in measures of Watts.