### PR TITLE
Improve path readability check

### DIFF
--- a/amdsmi_cli/amdsmi_helpers.py
+++ b/amdsmi_cli/amdsmi_helpers.py
@@ -1252,6 +1252,11 @@ class AMDSMIHelpers():
         if os.geteuid() == 0:
             return True, None, None
 
+        # Use os.access to check read permission (including ACLs) without
+        # opening the path, to avoid potential issues with device nodes.
+        if os.access(path, os.R_OK):
+            return True, None, None
+
         mode = st.st_mode
         uid = st.st_uid
         gid = st.st_gid


### PR DESCRIPTION
On modern system e.g. render nodes are made accessible via the udev uaccess functionality, which adds the logged in user to the ACL of the device. This means just checking for user and group is bound to give false positives. Instead simply try to open the device as a test and only if that fails try to determine the cause based on user/groups

## Motivation

Avoid false positives in readability tets

## Technical Details

On modern system e.g. render nodes are made accessible via the udev uaccess functionality, which adds the logged in user to the ACL of the device. This means just checking for user and group is bound to give false positives. Instead simply try to open the device as a test and only if that fails try to determine the cause based on user/groups

## Test Plan

Tested on framework desktop with devices managed by uaccess

## Test Result

Permission denied warnings without this change; No warnings without

## Submission Checklist

- [ x ] Look over the contributing guidelines at ha
